### PR TITLE
Fix inability to delete other users comments

### DIFF
--- a/app/controllers/storytime/comments_controller.rb
+++ b/app/controllers/storytime/comments_controller.rb
@@ -20,7 +20,7 @@ module Storytime
     end
 
     def destroy
-      @comment = current_user.storytime_comments.find(params[:id])
+      @comment = Comment.find(params[:id])
       authorize @comment
       @comment.destroy
       respond_with @comment


### PR DESCRIPTION
I'm not sure if this is intentional for now, however I encountered a bug where I was unable to delete other blog post comments (being an admin).

I figured that admins or editors should be able to delete other comments due to the Pundit policy here:
https://github.com/FlyoverWorks/storytime/blob/master/app/policies/storytime/comment_policy.rb#L23

Let me know if this is totally wrong and feel free to ignore :)
