### PR TITLE
Guard comments load on non-commentable post types

### DIFF
--- a/app/controllers/storytime/posts_controller.rb
+++ b/app/controllers/storytime/posts_controller.rb
@@ -15,7 +15,7 @@ module Storytime
       
       content_for :title, "#{@current_storytime_site.title} | #{@post.title}"
 
-      @comments = @post.comments.order("created_at DESC")
+      @comments = @post.comments.order("created_at DESC") if @post.show_comments?
       #allow overriding in the host app
       if params[:preview].nil? && !view_context.current_page?(storytime.post_path(@post))
         redirect_to storytime.post_path(@post), :status => :moved_permanently


### PR DESCRIPTION
## Summary
- `PostsController#show` was calling `@post.comments` unconditionally, but the `comments` association is only defined on `BlogPost` (via the `Storytime::PostComments` concern). Requests that resolved to a `Page` or `Blog` blew up with `NoMethodError: undefined method 'comments'`.
- Guard the load with `@post.show_comments?` — `Page` already overrides this to `false`, and `BlogPost` returns `true` via the concern. The show view at `app/views/storytime/posts/show.html.erb:25` already gates comment rendering with the same predicate, so `@comments` only needs to be set when comments are actually shown.

## Test plan
- [ ] Visit a `Page` route — page renders without 500
- [ ] Visit a `Blog` route — page renders without 500
- [ ] Visit a `BlogPost` route with comments — comments still render in created_at DESC order

🤖 Generated with [Claude Code](https://claude.com/claude-code)