### PR TITLE
Render 404 from PagesController#show when no page is loaded

### DIFF
--- a/app/controllers/storytime/pages_controller.rb
+++ b/app/controllers/storytime/pages_controller.rb
@@ -17,12 +17,18 @@ module Storytime
         "storytime/#{@current_storytime_site.custom_view_path}/pages/show",
         "storytime/pages/#{slug}",
         "storytime/pages/show",
-      ].each do |template|
+      ]
+
+      potential_templates.each do |template|
+        # The /show fallbacks dereference @page, so skip them when no page was loaded.
+        next if @page.nil? && template.end_with?("/show")
         if lookup_context.template_exists?(template)
           render template
           return
         end
       end
+
+      raise ActionController::RoutingError, "No page found for #{params[:id].inspect}"
     end
 
   private

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+# Request spec rather than controller spec so we go through the real engine
+# routes – the bug only manifests after the route's PageConstraint admits the
+# request to the controller.
+describe "Pages", type: :request do
+  let(:user) { FactoryBot.create(:admin) }
+  let!(:site) do
+    s = FactoryBot.create(:site, custom_domain: "www.example.com")
+    s.save_with_seeds(user)
+    s
+  end
+
+  before do
+    # Force the route's PageConstraint to admit the request so we can exercise
+    # the controller for ids the constraint would normally reject (like the
+    # leading-slash slugs that bots probe).
+    allow_any_instance_of(Storytime::Constraints::PageConstraint)
+      .to receive(:matches?).and_return(true)
+  end
+
+  describe "GET /:id when no page or slug-specific template matches" do
+    it "404s instead of falling through to a show template that requires @page" do
+      get "http://www.example.com/no-such-page"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s for malformed ids with a leading slash" do
+      # Bots hit URL-encoded paths like /%2Fcontact. The PageConstraint can let
+      # these through because POSIX collapses // in File.exist?, but the
+      # template resolver does not, so the controller must 404 explicitly
+      # rather than rendering the @page-dependent show template.
+      get "http://www.example.com/%2Fno-such-page"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes the recurring `ActionView::Template::Error: undefined method 'content' for nil` Airbrakes triggered by bots probing URL-encoded paths like `/%2Fcontact` and `/%2Fhome.php`.
- The route's `PageConstraint` admits these because POSIX collapses `//` in `File.exist?`, but Rails's template resolver does not. The controller then fell through to `storytime/pages/show`, which dereferences `@page` and crashes when no `Post` matched.
- Now: skip the `/show` fallback templates when `@page` is nil, and raise `ActionController::RoutingError` if nothing else matches, so these requests 404 instead of 500.

## Test plan
- [x] `bundle exec rspec spec/requests/pages_spec.rb` – new tests pass with the fix; both fail (500) without it.
- [x] `bundle exec rspec spec/requests/` – existing routing specs still green.