### PR TITLE
Block path traversal in PageConstraint (CVE-2026-38723)

### DIFF
--- a/lib/storytime/constraints/page_constraint.rb
+++ b/lib/storytime/constraints/page_constraint.rb
@@ -4,9 +4,15 @@ module Storytime
       include Storytime::Concerns::CurrentSite
 
       def matches?(request)
+        id = request.params[:id].to_s
+        # Reject path traversal: params[:id] comes from the "/*id" glob route, so it
+        # can contain "/" and ".." segments. sanitize() only strips HTML, not "../",
+        # which would let the File.exist? below probe arbitrary filesystem paths
+        return false if id.include?("..")
+
         site = current_storytime_site(request)
-        site.pages.friendly.exists?(request.params[:id]) ||
-        File.exist?(Rails.root.join('app', 'views', "storytime/#{site.custom_view_path}/pages/#{ActionController::Base.helpers.sanitize(request.params[:id])}.html.erb"))
+        site.pages.friendly.exists?(id) ||
+        File.exist?(Rails.root.join('app', 'views', "storytime/#{site.custom_view_path}/pages/#{ActionController::Base.helpers.sanitize(id)}.html.erb"))
       end
     end
   end

--- a/spec/lib/storytime/constraints/page_constraint_spec.rb
+++ b/spec/lib/storytime/constraints/page_constraint_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Storytime::Constraints::PageConstraint do
+  let(:site) { FactoryBot.create(:site) }
+  let(:constraint) { described_class.new }
+
+  def request_for(id)
+    instance_double("ActionDispatch::Request", params: { id: id }, host: site.custom_domain)
+  end
+
+  before do
+    Storytime::Site.current_id = site.id
+  end
+
+  after do
+    Storytime::Site.current_id = nil
+  end
+
+  it "matches an existing page slug" do
+    page = FactoryBot.create(:page, site: site)
+    expect(constraint.matches?(request_for(page.slug))).to be true
+  end
+
+  it "does not match an unknown slug" do
+    expect(constraint.matches?(request_for("no-such-page"))).to be false
+  end
+
+  context "with a path-traversal payload" do
+    let(:payload) { "a/../../../../../../../../etc/passwd" }
+
+    it "does not match" do
+      expect(constraint.matches?(request_for(payload))).to be false
+    end
+
+    it "never reaches the filesystem check" do
+      expect(File).not_to receive(:exist?)
+      constraint.matches?(request_for(payload))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`PageConstraint#matches?` interpolated `params[:id]` straight into a `File.exist?` lookup. Because the page route uses a **glob segment** (`get '/*id'`), `params[:id]` can contain `/` and `..` sequences, and `ActionController::Base.helpers.sanitize` strips HTML tags but **not** `../`. An unauthenticated attacker could therefore use the route as a filesystem existence oracle for `*.html.erb` paths (reported as CVE-2026-38723).

This rejects any `params[:id]` containing `..` before the filesystem check and adds a constraint spec covering the traversal case.

## Scope / impact notes

- **No arbitrary file read** — the `.html.erb` suffix is always appended and `File.exist?` only returns a boolean.
- The clean string oracle in the original report (`"No page found for"` vs `"No route matches"`) only manifests with `consider_all_requests_local = true` (development). In production both branches return a byte-identical 404; a weaker timing side-channel survives (the "exists" branch boots the controller + DB queries before raising). Confirmed empirically against the vulnerable code on Rails 8.1.3 / Puma 7.
- `custom_view_path` is `title.parameterize` (already strips `../`) and `layout` is an admin-only column, so `params[:id]` was the only unauthenticated vector. The fix short-circuits identically regardless of target, closing both the string and timing channels at the source.

## Test plan

- [x] `bundle exec rspec spec/lib/storytime/constraints/page_constraint_spec.rb` (4 examples, 0 failures)
- [x] `bundle exec rspec spec/requests` (8 examples, 0 failures)