### PR TITLE
Fix stored XSS in Snippet#content

### DIFF
--- a/app/models/storytime/snippet.rb
+++ b/app/models/storytime/snippet.rb
@@ -5,5 +5,16 @@ module Storytime
 
     validates :name, length: { in: 1..255 }
     validates :content, length: { in: 1..20000 }
+
+    before_save :sanitize_content
+
+    # Snippet content is rendered with `raw` in the front-end (see
+    # app/views/storytime/snippets/_snippet.html.erb), so it must be scrubbed
+    # on write with the same allow-list used for Post/Page content. Otherwise
+    # an editor could store arbitrary HTML/JS (stored XSS).
+    def sanitize_content
+      return if Storytime.post_sanitizer.blank? || content.blank?
+      self.content = Storytime.post_sanitizer.call(content)
+    end
   end
 end

--- a/db/migrate/20260701000000_sanitize_existing_storytime_snippets.rb
+++ b/db/migrate/20260701000000_sanitize_existing_storytime_snippets.rb
@@ -1,0 +1,22 @@
+class SanitizeExistingStorytimeSnippets < ActiveRecord::Migration[4.2]
+  # Snippet content was previously stored unsanitized and rendered with `raw`,
+  # allowing stored XSS. Re-run the sanitizer over every existing snippet so
+  # rows created before the before_save callback are scrubbed too.
+  def up
+    return if Storytime.post_sanitizer.blank?
+
+    Storytime::Snippet.reset_column_information
+    Storytime::Snippet.find_each do |snippet|
+      next if snippet.content.blank?
+
+      cleaned = Storytime.post_sanitizer.call(snippet.content)
+      next if cleaned == snippet.content
+
+      snippet.update_columns(content: cleaned)
+    end
+  end
+
+  def down
+    # Sanitization is not reversible; stripped markup cannot be restored.
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_001637) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/models/snippet_spec.rb
+++ b/spec/models/snippet_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Storytime::Snippet do
+  describe "#sanitize_content" do
+    it "strips script-bearing attributes from content on save" do
+      snippet = FactoryBot.create(:snippet, content: %(<img src=x onerror="alert(1)">))
+      expect(snippet.content).to_not include("onerror")
+    end
+
+    it "strips <script> tags from content on save" do
+      snippet = FactoryBot.create(:snippet, content: %(hello<script>alert(1)</script>))
+      expect(snippet.content).to_not include("<script")
+    end
+
+    it "re-sanitizes content on update" do
+      snippet = FactoryBot.create(:snippet, content: "safe")
+      snippet.update(content: %(<a href="javascript:alert(1)">x</a>))
+      expect(snippet.content).to_not include("javascript:")
+    end
+
+    it "preserves allowed markup" do
+      snippet = FactoryBot.create(:snippet, content: %(<p>hello <strong>world</strong></p>))
+      expect(snippet.content).to include("<strong>world</strong>")
+    end
+
+    it "leaves plain text unchanged" do
+      snippet = FactoryBot.create(:snippet, content: "just plain text")
+      expect(snippet.content).to eq("just plain text")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Storytime::Snippet#content` is rendered with `raw` in the snippet partial but, unlike `Post`/`Page` content, was never run through `Storytime.post_sanitizer` on write. A user with the editor role (which holds the "Manage Text Snippets" permission) could store arbitrary HTML/JS that then executes in every viewer's browser via the `storytime_snippet` helper, including unauthenticated visitors and admins. This is a stored XSS with an editor to admin privilege-escalation path.

Reported privately via coordinated disclosure. Fix mirrors the existing sanitization already applied to `Post`/`Page` content.

## Changes

- **`app/models/storytime/snippet.rb`** – sanitize `content` on write via `Storytime.post_sanitizer` in a `before_save` callback, bringing snippets to parity with posts/pages.
- **`db/migrate/20260701000000_sanitize_existing_storytime_snippets.rb`** – data migration re-sanitizing snippets already stored (the callback alone only protects new writes).
- **`spec/models/snippet_spec.rb`** – regression specs for script tags, event-handler attributes, and `javascript:` URLs, plus checks that allowed markup and plain text are preserved.
- **`spec/dummy/db/schema.rb`** – version bump from the new migration.

## Testing

`bundle exec rspec spec/models/snippet_spec.rb spec/models/post_spec.rb` → 14 examples, 0 failures.

## Follow-ups (separate)

- Add a Content-Security-Policy to the engine layouts as defense-in-depth.
- Enable GitHub private vulnerability reporting on the repo.
