### PR TITLE
Bump version to 2.1.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    storytime (2.1.6)
+    storytime (2.1.7)
       acts_as_list
       bootstrap-sass (>= 3.1)
       carrierwave (>= 3.0)

--- a/lib/storytime/version.rb
+++ b/lib/storytime/version.rb
@@ -1,3 +1,3 @@
 module Storytime
-  VERSION = "2.1.6"
+  VERSION = "2.1.7"
 end


### PR DESCRIPTION
Release cut carrying the Snippet stored-XSS fix (#288).

After merge, release from `main` with `bundle exec rake release` (tags `v2.1.7`, pushes, `gem push`).