### PR TITLE
Add private, gated HTML artifacts

### DIFF
--- a/app/assets/javascripts/storytime/base.js.coffee
+++ b/app/assets/javascripts/storytime/base.js.coffee
@@ -6,12 +6,22 @@ initJS = (controller, action) ->
     instance["init#{action}"]() if typeof(instance["init#{action}"]) == "function"
     Storytime.instance = instance
 
+  # Initialize any datepickers in freshly-rendered content (dashboard pages and
+  # ajax-loaded modals alike). The :not(.hasDatepicker) guard avoids re-init.
+  $(".datepicker:not(.hasDatepicker)").datepicker(dateFormat: "MM d, yy")
+
 $ ()->
   initJS($("body").data("controller"), $("body").data("action"))
 
   $(".flash").delay(4000).fadeOut() unless window.Storytime.test_env || window.Storytime.persistent_flash_message
 
   $(".chosen").chosen()
+
+  # Clear a datepicker field (e.g. to set "no expiration")
+  $(document).on 'click', '.js-clear-datepicker', (e) ->
+    e.preventDefault()
+    $("#" + $(@).data('target')).val('')
+    return
 
   $(document).on('ajax:beforeSend', '.btn-delete-resource', ()->
     $(@).attr("disabled", true)

--- a/app/assets/stylesheets/storytime/modals.scss
+++ b/app/assets/stylesheets/storytime/modals.scss
@@ -15,6 +15,10 @@
     margin: 0 auto;
     height: 100%;
 
+    @media (min-width: $screen-sm-min) {
+      width: 820px;
+    }
+
     .modal-content {
       height: 100%;
       @include border-top-radius(0);

--- a/app/controllers/storytime/api/v1/artifacts_controller.rb
+++ b/app/controllers/storytime/api/v1/artifacts_controller.rb
@@ -1,0 +1,116 @@
+require_dependency "storytime/application_controller"
+
+module Storytime
+  module Api
+    module V1
+      # Token-authenticated JSON API for creating/replacing/deleting artifacts
+      # programmatically. Authenticate with `Authorization: Bearer <token>`
+      # where the token matches Storytime.artifacts_api_token.
+      class ArtifactsController < ::Storytime::ApplicationController
+        layout false
+        protect_from_forgery with: :null_session
+        skip_before_action :verify_authenticity_token, raise: false
+
+        before_action :authenticate_api_token!
+        before_action :load_artifact, only: [:show, :update, :destroy]
+
+        def index
+          artifacts = Storytime::Artifact.order("created_at DESC")
+          render json: artifacts.map { |a| artifact_json(a) }
+        end
+
+        def show
+          render json: artifact_json(@artifact)
+        end
+
+        def create
+          artifact = Storytime::Artifact.new(name: params[:name])
+          artifact.site = current_storytime_site
+          artifact.user = api_user
+          assign_content(artifact)
+          assign_options(artifact)
+
+          if artifact.save
+            render json: artifact_json(artifact), status: :created
+          else
+            render json: { errors: artifact.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        def update
+          @artifact.name = params[:name] if params.key?(:name)
+          assign_content(@artifact)
+          assign_options(@artifact)
+
+          if @artifact.save
+            render json: artifact_json(@artifact)
+          else
+            render json: { errors: @artifact.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        def destroy
+          @artifact.destroy
+          head :no_content
+        end
+
+      private
+
+        def load_artifact
+          @artifact = Storytime::Artifact.find_by(token: params[:token])
+          head :not_found if @artifact.nil?
+        end
+
+        def assign_content(artifact)
+          if params[:file].respond_to?(:read)
+            artifact.assign_html(params[:file], filename: params[:file].try(:original_filename))
+          elsif params[:html].present?
+            artifact.assign_html(params[:html], filename: params[:filename])
+          end
+        end
+
+        def assign_options(artifact)
+          artifact.password = params[:password].presence if params.key?(:password)
+          artifact.expires_at = params[:expires_at].presence if params.key?(:expires_at)
+        end
+
+        def artifact_json(a)
+          {
+            token: a.token,
+            name: a.name,
+            url: artifact_url(a.token),
+            password_protected: a.password_protected?,
+            expires_at: a.expires_at,
+            byte_size: a.byte_size,
+            created_at: a.created_at,
+            updated_at: a.updated_at
+          }
+        end
+
+        def authenticate_api_token!
+          configured = Storytime.artifacts_api_token.to_s
+          provided = bearer_token.to_s
+
+          if configured.blank? || provided.blank? || !secure_match?(provided, configured)
+            render json: { error: "Unauthorized" }, status: :unauthorized
+          end
+        end
+
+        def secure_match?(a, b)
+          ActiveSupport::SecurityUtils.secure_compare(
+            ::Digest::SHA256.hexdigest(a),
+            ::Digest::SHA256.hexdigest(b)
+          )
+        end
+
+        def bearer_token
+          request.authorization.to_s[/\ABearer\s+(.+)\z/i, 1] || params[:api_token]
+        end
+
+        def api_user
+          current_storytime_site.try(:creator) || Storytime.user_class.first
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/storytime/api/v1/artifacts_controller.rb
+++ b/app/controllers/storytime/api/v1/artifacts_controller.rb
@@ -88,18 +88,34 @@ module Storytime
           }
         end
 
+        # A token is accepted only when it is valid, belongs to the site being
+        # addressed (by request host), and its owner still has artifact-manage
+        # rights on that site. This keeps a token minted for one site from
+        # acting on another, and revokes access if the owner's role changes.
+        # A single 401 for every failure mode avoids leaking whether a token is
+        # valid on some other site.
         def authenticate_api_token!
           @api_token = Storytime::ApiToken.authenticate(bearer_token)
 
-          if @api_token.nil?
+          if @api_token.nil? || !token_scoped_to_current_site? || !token_user_authorized?
             render json: { error: "Unauthorized" }, status: :unauthorized
           else
             @api_token.touch_last_used!
           end
         end
 
+        def token_scoped_to_current_site?
+          @api_token.site_id.present? && @api_token.site_id == current_storytime_site.id
+        end
+
+        def token_user_authorized?
+          Storytime::ArtifactPolicy.new(@api_token.user, Storytime::Artifact).manage?
+        end
+
+        # Header-only: never read the token from query/body params, which would
+        # otherwise land in server logs, browser history, and Referer headers.
         def bearer_token
-          request.authorization.to_s[/\ABearer\s+(.+)\z/i, 1] || params[:api_token]
+          request.authorization.to_s[/\ABearer\s+(.+)\z/i, 1]
         end
       end
     end

--- a/app/controllers/storytime/api/v1/artifacts_controller.rb
+++ b/app/controllers/storytime/api/v1/artifacts_controller.rb
@@ -5,7 +5,8 @@ module Storytime
     module V1
       # Token-authenticated JSON API for creating/replacing/deleting artifacts
       # programmatically. Authenticate with `Authorization: Bearer <token>`
-      # where the token matches Storytime.artifacts_api_token.
+      # using a token minted in the dashboard (Site Settings -> API Tokens).
+      # Created artifacts are attributed to the token's owner.
       class ArtifactsController < ::Storytime::ApplicationController
         layout false
         protect_from_forgery with: :null_session
@@ -26,7 +27,7 @@ module Storytime
         def create
           artifact = Storytime::Artifact.new(name: params[:name])
           artifact.site = current_storytime_site
-          artifact.user = api_user
+          artifact.user = @api_token.user
           assign_content(artifact)
           assign_options(artifact)
 
@@ -88,27 +89,17 @@ module Storytime
         end
 
         def authenticate_api_token!
-          configured = Storytime.artifacts_api_token.to_s
-          provided = bearer_token.to_s
+          @api_token = Storytime::ApiToken.authenticate(bearer_token)
 
-          if configured.blank? || provided.blank? || !secure_match?(provided, configured)
+          if @api_token.nil?
             render json: { error: "Unauthorized" }, status: :unauthorized
+          else
+            @api_token.touch_last_used!
           end
-        end
-
-        def secure_match?(a, b)
-          ActiveSupport::SecurityUtils.secure_compare(
-            ::Digest::SHA256.hexdigest(a),
-            ::Digest::SHA256.hexdigest(b)
-          )
         end
 
         def bearer_token
           request.authorization.to_s[/\ABearer\s+(.+)\z/i, 1] || params[:api_token]
-        end
-
-        def api_user
-          current_storytime_site.try(:creator) || Storytime.user_class.first
         end
       end
     end

--- a/app/controllers/storytime/api/v1/artifacts_controller.rb
+++ b/app/controllers/storytime/api/v1/artifacts_controller.rb
@@ -59,7 +59,7 @@ module Storytime
 
         def load_artifact
           @artifact = Storytime::Artifact.find_by(token: params[:token])
-          head :not_found if @artifact.nil?
+          return head :not_found if @artifact.nil?
         end
 
         def assign_content(artifact)
@@ -99,9 +99,10 @@ module Storytime
 
           if @api_token.nil? || !token_scoped_to_current_site? || !token_user_authorized?
             render json: { error: "Unauthorized" }, status: :unauthorized
-          else
-            @api_token.touch_last_used!
+            return
           end
+
+          @api_token.touch_last_used!
         end
 
         def token_scoped_to_current_site?

--- a/app/controllers/storytime/artifacts_controller.rb
+++ b/app/controllers/storytime/artifacts_controller.rb
@@ -5,22 +5,58 @@ module Storytime
   # Public, token-addressed serving of artifacts. No dashboard auth: access is
   # controlled by the unguessable token, an optional password gate (remembered
   # per-artifact in the session), and an optional expiration date.
+  #
+  # The artifact HTML is never rendered on the app's own origin. `#show` returns
+  # a trusted wrapper page that embeds the content (served by `#raw`) in a
+  # sandboxed iframe, so the artifact's scripts run in an opaque origin and
+  # cannot reach the app's cookies, DOM, or authenticated same-origin requests.
   class ArtifactsController < ApplicationController
     layout false
+
+    # Capabilities granted to the artifact iframe, applied both as the iframe's
+    # `sandbox` attribute and as a matching `Content-Security-Policy: sandbox`
+    # on the raw response (so a direct hit is sandboxed identically).
+    # Deliberately WITHOUT `allow-same-origin` (that, combined with
+    # `allow-scripts`, would let the frame drop its own sandbox) and without
+    # `allow-top-navigation` (so an artifact can't redirect the parent page).
+    SANDBOX_TOKENS = "allow-scripts allow-popups allow-popups-to-escape-sandbox " \
+                     "allow-forms allow-downloads allow-modals".freeze
+
+    # Brute-force guard for the password gate: at most this many failed unlock
+    # attempts per artifact+IP within the rolling window before we stop checking.
+    MAX_UNLOCK_ATTEMPTS = 10
+    UNLOCK_WINDOW = 15.minutes
 
     before_action :load_artifact
 
     def show
-      return render_password_form if @artifact.password_protected? && !unlocked?
+      return render_password_form if locked?
+
+      set_noindex_headers
+      @sandbox_tokens = SANDBOX_TOKENS
+      render "storytime/artifacts/show"
+    end
+
+    # The sandboxed artifact document itself, embedded by #show's iframe. Gated
+    # identically to #show so the content can't be fetched while still locked.
+    def raw
+      return not_found if locked?
 
       deliver_artifact
     end
 
     def unlock
+      if unlock_throttled?
+        flash.now[:artifact_error] = "Too many attempts. Please wait a few minutes and try again."
+        return render_password_form(status: :too_many_requests)
+      end
+
       if @artifact.password_protected? && @artifact.authenticate(params[:password].to_s)
+        clear_unlock_attempts
         unlocked_tokens[@artifact.token] = unlock_fingerprint
         redirect_to artifact_path(@artifact.token)
       else
+        register_unlock_attempt
         flash.now[:artifact_error] = "Incorrect password. Please try again."
         render_password_form(status: :unauthorized)
       end
@@ -36,9 +72,16 @@ module Storytime
 
     def deliver_artifact
       set_noindex_headers
+      # Sandbox the response itself, so even a direct navigation to the raw URL
+      # renders in an opaque origin rather than the app's.
+      response.set_header("Content-Security-Policy", "sandbox #{SANDBOX_TOKENS}")
       send_data @artifact.content,
                 type: "text/html; charset=utf-8",
                 disposition: "inline"
+    end
+
+    def locked?
+      @artifact.password_protected? && !unlocked?
     end
 
     def render_password_form(status: :ok)
@@ -48,6 +91,26 @@ module Storytime
 
     def set_noindex_headers
       response.set_header("X-Robots-Tag", "noindex, nofollow, noarchive")
+      # Artifacts are served with an explicit text/html type; stop browsers from
+      # MIME-sniffing the stored content into some other executable type.
+      response.set_header("X-Content-Type-Options", "nosniff")
+    end
+
+    def unlock_throttled?
+      Rails.cache.read(unlock_attempts_key).to_i >= MAX_UNLOCK_ATTEMPTS
+    end
+
+    def register_unlock_attempt
+      count = Rails.cache.read(unlock_attempts_key).to_i + 1
+      Rails.cache.write(unlock_attempts_key, count, expires_in: UNLOCK_WINDOW)
+    end
+
+    def clear_unlock_attempts
+      Rails.cache.delete(unlock_attempts_key)
+    end
+
+    def unlock_attempts_key
+      "storytime:artifact_unlock:#{@artifact.token}:#{request.remote_ip}"
     end
 
     def unlocked?

--- a/app/controllers/storytime/artifacts_controller.rb
+++ b/app/controllers/storytime/artifacts_controller.rb
@@ -27,6 +27,11 @@ module Storytime
     MAX_UNLOCK_ATTEMPTS = 10
     UNLOCK_WINDOW = 15.minutes
 
+    # Cap how many artifact unlocks we remember per session. Unlocks live in the
+    # cookie session store (~4KB), so an unbounded hash could overflow it and
+    # break requests; keep only the most recently unlocked artifacts.
+    MAX_REMEMBERED_UNLOCKS = 20
+
     before_action :load_artifact
 
     def show
@@ -53,7 +58,7 @@ module Storytime
 
       if @artifact.password_protected? && @artifact.authenticate(params[:password].to_s)
         clear_unlock_attempts
-        unlocked_tokens[@artifact.token] = unlock_fingerprint
+        remember_unlock
         redirect_to artifact_path(@artifact.token)
       else
         register_unlock_attempt
@@ -126,6 +131,19 @@ module Storytime
 
     def unlocked_tokens
       session[:storytime_unlocked_artifacts] ||= {}
+    end
+
+    # Record the current artifact as unlocked, keeping the stored set bounded.
+    # Re-inserting moves this token to the most-recent position, and we drop the
+    # oldest entries beyond MAX_REMEMBERED_UNLOCKS so the session cookie can't
+    # grow without bound.
+    def remember_unlock
+      tokens = unlocked_tokens
+      tokens.delete(@artifact.token)
+      tokens[@artifact.token] = unlock_fingerprint
+      if tokens.size > MAX_REMEMBERED_UNLOCKS
+        tokens.keys.first(tokens.size - MAX_REMEMBERED_UNLOCKS).each { |k| tokens.delete(k) }
+      end
     end
 
     def not_found

--- a/app/controllers/storytime/artifacts_controller.rb
+++ b/app/controllers/storytime/artifacts_controller.rb
@@ -1,3 +1,4 @@
+require "digest"
 require_dependency "storytime/application_controller"
 
 module Storytime
@@ -17,7 +18,7 @@ module Storytime
 
     def unlock
       if @artifact.password_protected? && @artifact.authenticate(params[:password].to_s)
-        unlocked_tokens[@artifact.token] = true
+        unlocked_tokens[@artifact.token] = unlock_fingerprint
         redirect_to artifact_path(@artifact.token)
       else
         flash.now[:artifact_error] = "Incorrect password. Please try again."
@@ -50,7 +51,14 @@ module Storytime
     end
 
     def unlocked?
-      unlocked_tokens[@artifact.token] == true
+      unlocked_tokens[@artifact.token] == unlock_fingerprint
+    end
+
+    # Ties a session unlock to the current password. Rotating, removing, or
+    # re-adding the password changes the digest, so any earlier unlock stored in
+    # the session no longer matches and the visitor must re-enter the password.
+    def unlock_fingerprint
+      Digest::SHA256.hexdigest(@artifact.password_digest.to_s)
     end
 
     def unlocked_tokens

--- a/app/controllers/storytime/artifacts_controller.rb
+++ b/app/controllers/storytime/artifacts_controller.rb
@@ -1,0 +1,64 @@
+require_dependency "storytime/application_controller"
+
+module Storytime
+  # Public, token-addressed serving of artifacts. No dashboard auth: access is
+  # controlled by the unguessable token, an optional password gate (remembered
+  # per-artifact in the session), and an optional expiration date.
+  class ArtifactsController < ApplicationController
+    layout false
+
+    before_action :load_artifact
+
+    def show
+      return render_password_form if @artifact.password_protected? && !unlocked?
+
+      deliver_artifact
+    end
+
+    def unlock
+      if @artifact.password_protected? && @artifact.authenticate(params[:password].to_s)
+        unlocked_tokens[@artifact.token] = true
+        redirect_to artifact_path(@artifact.token)
+      else
+        flash.now[:artifact_error] = "Incorrect password. Please try again."
+        render_password_form(status: :unauthorized)
+      end
+    end
+
+  private
+
+    def load_artifact
+      # Scoped to the current site via ScopedToSite; tokens are globally unique.
+      @artifact = Storytime::Artifact.find_by(token: params[:token])
+      not_found if @artifact.nil? || @artifact.expired?
+    end
+
+    def deliver_artifact
+      set_noindex_headers
+      send_data @artifact.content,
+                type: "text/html; charset=utf-8",
+                disposition: "inline"
+    end
+
+    def render_password_form(status: :ok)
+      set_noindex_headers
+      render "storytime/artifacts/password", status: status
+    end
+
+    def set_noindex_headers
+      response.set_header("X-Robots-Tag", "noindex, nofollow, noarchive")
+    end
+
+    def unlocked?
+      unlocked_tokens[@artifact.token] == true
+    end
+
+    def unlocked_tokens
+      session[:storytime_unlocked_artifacts] ||= {}
+    end
+
+    def not_found
+      raise ActionController::RoutingError, "Artifact not found"
+    end
+  end
+end

--- a/app/controllers/storytime/dashboard/api_tokens_controller.rb
+++ b/app/controllers/storytime/dashboard/api_tokens_controller.rb
@@ -1,0 +1,56 @@
+require_dependency "storytime/application_controller"
+
+module Storytime
+  module Dashboard
+    class ApiTokensController < DashboardController
+      respond_to :json
+
+      before_action :load_api_tokens, only: [:index, :create]
+      before_action :load_api_token, only: [:destroy]
+
+      def index
+        authorize Storytime::ApiToken
+        respond_with @api_tokens
+      end
+
+      def create
+        @api_token = Storytime::ApiToken.new(name: api_token_params[:name])
+        @api_token.user = current_user
+        @api_token.site = current_storytime_site
+        @api_token.expires_at = api_token_params[:expires_at].presence
+        authorize @api_token
+
+        respond_to do |format|
+          if @api_token.save
+            # Surface the raw token once so the panel can display it.
+            @created_token = @api_token.raw_token
+            load_api_tokens
+            format.json { render :index }
+          else
+            format.json { render :index, status: :unprocessable_entity }
+          end
+        end
+      end
+
+      def destroy
+        authorize @api_token
+        @api_token.destroy
+        respond_with @api_token
+      end
+
+    private
+
+      def load_api_tokens
+        @api_tokens = Storytime::ApiToken.order("created_at DESC")
+      end
+
+      def load_api_token
+        @api_token = Storytime::ApiToken.find(params[:id])
+      end
+
+      def api_token_params
+        params.require(:api_token).permit(:name, :expires_at)
+      end
+    end
+  end
+end

--- a/app/controllers/storytime/dashboard/api_tokens_controller.rb
+++ b/app/controllers/storytime/dashboard/api_tokens_controller.rb
@@ -17,7 +17,7 @@ module Storytime
         @api_token = Storytime::ApiToken.new(name: api_token_params[:name])
         @api_token.user = current_user
         @api_token.site = current_storytime_site
-        @api_token.expires_at = api_token_params[:expires_at].presence
+        @api_token.expires_at = parse_expiration(api_token_params[:expires_at])
         authorize @api_token
 
         respond_to do |format|

--- a/app/controllers/storytime/dashboard/artifacts_controller.rb
+++ b/app/controllers/storytime/dashboard/artifacts_controller.rb
@@ -1,0 +1,78 @@
+require_dependency "storytime/application_controller"
+
+module Storytime
+  module Dashboard
+    class ArtifactsController < DashboardController
+      before_action :load_artifact, only: [:edit, :update, :destroy]
+
+      def index
+        @artifacts = Storytime::Artifact.order("created_at DESC").page(params[:page]).per(20)
+        authorize @artifacts
+      end
+
+      def new
+        @artifact = Storytime::Artifact.new
+        authorize @artifact
+      end
+
+      def create
+        @artifact = Storytime::Artifact.new(name: artifact_params[:name])
+        @artifact.user = current_user
+        @artifact.site = current_storytime_site
+        apply_form_attributes(@artifact)
+        authorize @artifact
+
+        if @artifact.save
+          redirect_to [:dashboard, :artifacts], notice: "Artifact created."
+        else
+          render :new
+        end
+      end
+
+      def edit
+        authorize @artifact
+      end
+
+      def update
+        authorize @artifact
+        @artifact.name = artifact_params[:name] if artifact_params.key?(:name)
+        apply_form_attributes(@artifact)
+
+        if @artifact.save
+          redirect_to [:dashboard, :artifacts], notice: "Artifact updated."
+        else
+          render :edit
+        end
+      end
+
+      def destroy
+        authorize @artifact
+        @artifact.destroy
+        redirect_to [:dashboard, :artifacts], notice: "Artifact deleted."
+      end
+
+    private
+
+      def load_artifact
+        @artifact = Storytime::Artifact.find_by!(token: params[:id])
+      end
+
+      def apply_form_attributes(artifact)
+        file = artifact_params[:file]
+        artifact.assign_html(file, filename: file.original_filename) if file.present?
+
+        if artifact_params[:remove_password] == "1"
+          artifact.password = nil
+        elsif artifact_params[:password].present?
+          artifact.password = artifact_params[:password]
+        end
+
+        artifact.expires_at = artifact_params[:expires_at].presence if artifact_params.key?(:expires_at)
+      end
+
+      def artifact_params
+        params.require(:artifact).permit(:name, :file, :password, :remove_password, :expires_at)
+      end
+    end
+  end
+end

--- a/app/controllers/storytime/dashboard/artifacts_controller.rb
+++ b/app/controllers/storytime/dashboard/artifacts_controller.rb
@@ -67,7 +67,7 @@ module Storytime
           artifact.password = artifact_params[:password]
         end
 
-        artifact.expires_at = artifact_params[:expires_at].presence if artifact_params.key?(:expires_at)
+        artifact.expires_at = parse_expiration(artifact_params[:expires_at]) if artifact_params.key?(:expires_at)
       end
 
       def artifact_params

--- a/app/controllers/storytime/dashboard/artifacts_controller.rb
+++ b/app/controllers/storytime/dashboard/artifacts_controller.rb
@@ -19,8 +19,10 @@ module Storytime
         @artifact = Storytime::Artifact.new(name: artifact_params[:name])
         @artifact.user = current_user
         @artifact.site = current_storytime_site
-        apply_form_attributes(@artifact)
+        # Authorize before processing the upload so an unauthorized request never
+        # reads the file into memory.
         authorize @artifact
+        apply_form_attributes(@artifact)
 
         if @artifact.save
           redirect_to [:dashboard, :artifacts], notice: "Artifact created."

--- a/app/controllers/storytime/dashboard_controller.rb
+++ b/app/controllers/storytime/dashboard_controller.rb
@@ -31,7 +31,10 @@ module Storytime
     # or nil when blank/unparseable (meaning "no expiration").
     def parse_expiration(value)
       return nil if value.blank?
-      Time.zone.parse(value.to_s).end_of_day
+      # Time.zone.parse returns nil for strings with no date tokens and raises
+      # ArgumentError for out-of-range dates; guard against both.
+      parsed = Time.zone.parse(value.to_s)
+      parsed&.end_of_day
     rescue ArgumentError
       nil
     end

--- a/app/controllers/storytime/dashboard_controller.rb
+++ b/app/controllers/storytime/dashboard_controller.rb
@@ -26,5 +26,14 @@ module Storytime
     def admin_controller?
       false
     end
+
+    # Parses a datepicker value (e.g. "July 8, 2026") into an end-of-day time,
+    # or nil when blank/unparseable (meaning "no expiration").
+    def parse_expiration(value)
+      return nil if value.blank?
+      Time.zone.parse(value.to_s).end_of_day
+    rescue ArgumentError
+      nil
+    end
   end
 end

--- a/app/models/storytime/api_token.rb
+++ b/app/models/storytime/api_token.rb
@@ -30,8 +30,10 @@ module Storytime
       ::Digest::SHA256.hexdigest(raw.to_s)
     end
 
-    # Returns the matching active token for a raw bearer token, or nil.
-    # Not site-scoped: tokens are globally unique by digest.
+    # Returns the matching active token for a raw bearer token, or nil. Looks up
+    # by globally-unique digest and is intentionally NOT site-scoped; callers
+    # MUST enforce that the token's site matches the site being acted on (see
+    # Api::V1::ArtifactsController#authenticate_api_token!).
     def self.authenticate(raw)
       return if raw.blank?
 

--- a/app/models/storytime/api_token.rb
+++ b/app/models/storytime/api_token.rb
@@ -8,7 +8,7 @@ module Storytime
   class ApiToken < ActiveRecord::Base
     include Storytime::ScopedToSite
 
-    PREFIX = "sk_".freeze
+    PREFIX = "sk_stime_".freeze
 
     belongs_to :user, class_name: Storytime.user_class.to_s, optional: true
     belongs_to :site, optional: true
@@ -57,7 +57,8 @@ module Storytime
       end
 
       self.token_digest = self.class.digest(@raw_token)
-      self.token_prefix = @raw_token[0, 11]
+      # Store the source prefix plus a few chars to identify the token later.
+      self.token_prefix = @raw_token[0, PREFIX.length + 6]
     end
   end
 end

--- a/app/models/storytime/api_token.rb
+++ b/app/models/storytime/api_token.rb
@@ -1,0 +1,63 @@
+require "digest"
+
+module Storytime
+  # A named, revocable API credential. Only a SHA-256 digest of the token is
+  # stored; the raw token is shown once at creation and never persisted. Each
+  # token belongs to a user, so artifacts created via the API are attributed to
+  # a real person.
+  class ApiToken < ActiveRecord::Base
+    include Storytime::ScopedToSite
+
+    PREFIX = "sk_".freeze
+
+    belongs_to :user, class_name: Storytime.user_class.to_s, optional: true
+    belongs_to :site, optional: true
+
+    validates :name, presence: true
+    validates :token_digest, presence: true, uniqueness: true
+
+    # Holds the raw token immediately after generation so it can be displayed
+    # once. Never populated when loading an existing record.
+    attr_reader :raw_token
+
+    before_validation :generate_token, on: :create
+
+    scope :active, -> {
+      where("storytime_api_tokens.expires_at IS NULL OR storytime_api_tokens.expires_at > ?", Time.current)
+    }
+
+    def self.digest(raw)
+      ::Digest::SHA256.hexdigest(raw.to_s)
+    end
+
+    # Returns the matching active token for a raw bearer token, or nil.
+    # Not site-scoped: tokens are globally unique by digest.
+    def self.authenticate(raw)
+      return if raw.blank?
+
+      unscoped.active.find_by(token_digest: digest(raw))
+    end
+
+    def expired?
+      expires_at.present? && expires_at <= Time.current
+    end
+
+    def touch_last_used!
+      update_column(:last_used_at, Time.current)
+    end
+
+  private
+
+    def generate_token
+      return if token_digest.present?
+
+      @raw_token = loop do
+        candidate = PREFIX + SecureRandom.alphanumeric(40)
+        break candidate unless Storytime::ApiToken.unscoped.exists?(token_digest: self.class.digest(candidate))
+      end
+
+      self.token_digest = self.class.digest(@raw_token)
+      self.token_prefix = @raw_token[0, 11]
+    end
+  end
+end

--- a/app/models/storytime/artifact.rb
+++ b/app/models/storytime/artifact.rb
@@ -13,11 +13,16 @@ module Storytime
     # while still giving us `password=` and `authenticate`.
     has_secure_password :password, validations: false
 
+    # Upper bound on stored HTML. Guards against unbounded DB/session growth and
+    # trivial storage-exhaustion. Generous enough for HTML with inlined assets.
+    MAX_CONTENT_BYTES = 10.megabytes
+
     before_validation :ensure_token, on: :create
 
     validates :name, presence: true
     validates :token, presence: true, uniqueness: true
     validates :content, presence: true
+    validate :content_within_size_limit
 
     scope :active, -> {
       where("storytime_artifacts.expires_at IS NULL OR storytime_artifacts.expires_at > ?", Time.current)
@@ -48,6 +53,13 @@ module Storytime
     end
 
   private
+
+    def content_within_size_limit
+      return if content.blank?
+      return if content.bytesize <= MAX_CONTENT_BYTES
+
+      errors.add(:content, "is too large (maximum is #{MAX_CONTENT_BYTES / 1.megabyte} MB)")
+    end
 
     def ensure_token
       return if token.present?

--- a/app/models/storytime/artifact.rb
+++ b/app/models/storytime/artifact.rb
@@ -1,0 +1,61 @@
+module Storytime
+  # A self-contained HTML artifact (CSS/JS/images inlined) served from a
+  # private, unguessable token URL. Optionally gated by a password and/or an
+  # expiration date. Content is stored in the database so access control can be
+  # enforced on every request rather than relying on a public asset URL.
+  class Artifact < ActiveRecord::Base
+    include Storytime::ScopedToSite
+
+    belongs_to :user, class_name: Storytime.user_class.to_s, optional: true
+    belongs_to :site, optional: true
+
+    # Optional password gate. `validations: false` keeps the password optional
+    # while still giving us `password=` and `authenticate`.
+    has_secure_password :password, validations: false
+
+    before_validation :ensure_token, on: :create
+
+    validates :name, presence: true
+    validates :token, presence: true, uniqueness: true
+    validates :content, presence: true
+
+    scope :active, -> {
+      where("storytime_artifacts.expires_at IS NULL OR storytime_artifacts.expires_at > ?", Time.current)
+    }
+
+    def to_param
+      token
+    end
+
+    def expired?
+      expires_at.present? && expires_at <= Time.current
+    end
+
+    def password_protected?
+      password_digest.present?
+    end
+
+    # Accepts a raw string or an uploaded file (anything that responds to
+    # #read) and stores it as the artifact's HTML content.
+    def assign_html(io_or_string, filename: nil)
+      data = io_or_string.respond_to?(:read) ? io_or_string.read : io_or_string
+      data = data.to_s
+      data = data.dup.force_encoding("UTF-8")
+      self.content = data
+      self.byte_size = data.bytesize
+      self.content_type = "text/html"
+      self.original_filename = filename if filename.present?
+    end
+
+  private
+
+    def ensure_token
+      return if token.present?
+
+      self.token = loop do
+        candidate = SecureRandom.urlsafe_base64(24)
+        break candidate unless Storytime::Artifact.unscoped.exists?(token: candidate)
+      end
+    end
+  end
+end

--- a/app/models/storytime/artifact.rb
+++ b/app/models/storytime/artifact.rb
@@ -53,7 +53,7 @@ module Storytime
       return if token.present?
 
       self.token = loop do
-        candidate = SecureRandom.urlsafe_base64(24)
+        candidate = SecureRandom.alphanumeric(32)
         break candidate unless Storytime::Artifact.unscoped.exists?(token: candidate)
       end
     end

--- a/app/models/storytime/artifact.rb
+++ b/app/models/storytime/artifact.rb
@@ -44,8 +44,12 @@ module Storytime
     # #read) and stores it as the artifact's HTML content.
     def assign_html(io_or_string, filename: nil)
       data = io_or_string.respond_to?(:read) ? io_or_string.read : io_or_string
-      data = data.to_s
-      data = data.dup.force_encoding("UTF-8")
+      data = data.to_s.dup
+      # Interpret the bytes as UTF-8 and scrub any invalid/undefined sequences to
+      # the Unicode replacement char. Uploads that aren't valid UTF-8 (Latin-1,
+      # binary, etc.) would otherwise raise on the PG insert instead of storing
+      # cleanly; `scrub` guarantees valid UTF-8 (a no-op when already valid).
+      data = data.force_encoding("UTF-8").scrub
       self.content = data
       self.byte_size = data.bytesize
       self.content_type = "text/html"

--- a/app/policies/storytime/api_token_policy.rb
+++ b/app/policies/storytime/api_token_policy.rb
@@ -1,0 +1,22 @@
+module Storytime
+  class ApiTokenPolicy
+    attr_reader :user, :api_token
+
+    def initialize(user, api_token)
+      @user = user
+      @api_token = api_token
+    end
+
+    def index?
+      !@user.nil?
+    end
+
+    def create?
+      !@user.nil?
+    end
+
+    def destroy?
+      !@user.nil?
+    end
+  end
+end

--- a/app/policies/storytime/api_token_policy.rb
+++ b/app/policies/storytime/api_token_policy.rb
@@ -1,4 +1,6 @@
 module Storytime
+  # API tokens grant programmatic artifact creation, so they are restricted to
+  # users who can manage site settings (admins), matching ArtifactPolicy.
   class ApiTokenPolicy
     attr_reader :user, :api_token
 
@@ -8,15 +10,23 @@ module Storytime
     end
 
     def index?
-      !@user.nil?
+      manage?
     end
 
     def create?
-      !@user.nil?
+      manage?
     end
 
     def destroy?
-      !@user.nil?
+      manage?
+    end
+
+    def manage?
+      return false if @user.nil?
+
+      action = Storytime::Action.find_by(guid: "47342a")
+      role = @user.storytime_role_in_site(Storytime::Site.current)
+      role.present? && role.allowed_actions.include?(action)
     end
   end
 end

--- a/app/policies/storytime/artifact_policy.rb
+++ b/app/policies/storytime/artifact_policy.rb
@@ -1,4 +1,8 @@
 module Storytime
+  # Artifacts are arbitrary HTML/JS served from the site origin, so authoring is
+  # restricted to users who can manage site settings (admins) rather than any
+  # signed-in member. This keeps a low-privilege writer from planting an
+  # executable page under the production domain.
   class ArtifactPolicy
     attr_reader :user, :artifact
 
@@ -8,27 +12,35 @@ module Storytime
     end
 
     def index?
-      !@user.nil?
+      manage?
     end
 
     def new?
-      !@user.nil?
+      manage?
     end
 
     def create?
-      !@user.nil?
+      manage?
     end
 
     def edit?
-      !@user.nil?
+      manage?
     end
 
     def update?
-      !@user.nil?
+      manage?
     end
 
     def destroy?
-      !@user.nil?
+      manage?
+    end
+
+    def manage?
+      return false if @user.nil?
+
+      action = Storytime::Action.find_by(guid: "47342a")
+      role = @user.storytime_role_in_site(Storytime::Site.current)
+      role.present? && role.allowed_actions.include?(action)
     end
   end
 end

--- a/app/policies/storytime/artifact_policy.rb
+++ b/app/policies/storytime/artifact_policy.rb
@@ -1,0 +1,34 @@
+module Storytime
+  class ArtifactPolicy
+    attr_reader :user, :artifact
+
+    def initialize(user, artifact)
+      @user = user
+      @artifact = artifact
+    end
+
+    def index?
+      !@user.nil?
+    end
+
+    def new?
+      !@user.nil?
+    end
+
+    def create?
+      !@user.nil?
+    end
+
+    def edit?
+      !@user.nil?
+    end
+
+    def update?
+      !@user.nil?
+    end
+
+    def destroy?
+      !@user.nil?
+    end
+  end
+end

--- a/app/views/storytime/artifacts/password.html.erb
+++ b/app/views/storytime/artifacts/password.html.erb
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow, noarchive">
+  <title><%= @artifact.name %></title>
+  <style>
+    :root {
+      --bg: #f5f7f9; --surface: #ffffff; --line: #dde3ea;
+      --ink: #171c26; --muted: #5a6675; --accent: #0f7d82; --error: #c14318;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #10131a; --surface: #181c25; --line: #2b323d;
+        --ink: #e7ecf3; --muted: #9aa6b6; --accent: #3bb2b7; --error: #f2926a;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+      background: var(--bg); color: var(--ink); padding: 24px;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; line-height: 1.5;
+    }
+    .card {
+      background: var(--surface); border: 1px solid var(--line); border-radius: 12px;
+      padding: 32px; width: 100%; max-width: 380px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.05), 0 8px 30px rgba(0,0,0,.08);
+    }
+    h1 { font-size: 20px; margin: 0 0 6px; letter-spacing: -.01em; }
+    p.sub { margin: 0 0 20px; color: var(--muted); font-size: 14px; }
+    label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; }
+    input[type=password] {
+      width: 100%; font-size: 15px; padding: 10px 12px; border-radius: 8px;
+      border: 1px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    input[type=password]:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+    button {
+      margin-top: 16px; width: 100%; font-size: 15px; font-weight: 600; cursor: pointer;
+      padding: 11px 12px; border-radius: 8px; border: none; background: var(--accent); color: #fff;
+    }
+    .error { color: var(--error); font-size: 13px; margin: 0 0 14px; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Password required</h1>
+    <p class="sub">This content is protected. Enter the password to continue.</p>
+    <% if flash[:artifact_error].present? %>
+      <p class="error"><%= flash[:artifact_error] %></p>
+    <% end %>
+    <%= form_with url: unlock_artifact_path(@artifact.token), method: :post do %>
+      <label for="password">Password</label>
+      <%= password_field_tag :password, nil, id: "password", autofocus: true, autocomplete: "current-password" %>
+      <button type="submit">Unlock</button>
+    <% end %>
+  </main>
+</body>
+</html>

--- a/app/views/storytime/artifacts/show.html.erb
+++ b/app/views/storytime/artifacts/show.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow, noarchive">
+  <title><%= @artifact.name %></title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; background: #fff; }
+    /* The artifact renders full-viewport inside an isolated, sandboxed frame. */
+    iframe.artifact-frame {
+      display: block; border: 0; width: 100%; height: 100vh;
+    }
+  </style>
+</head>
+<body>
+  <iframe class="artifact-frame"
+          src="<%= raw_artifact_path(@artifact.token) %>"
+          sandbox="<%= @sandbox_tokens %>"
+          title="<%= @artifact.name %>"></iframe>
+</body>
+</html>

--- a/app/views/storytime/dashboard/_navigation.html.erb
+++ b/app/views/storytime/dashboard/_navigation.html.erb
@@ -34,6 +34,12 @@
               <span style="margin-left: 10px; margin-right: 6px;">Permissions</span>
             <% end %>
           </li>
+          <li>
+            <%= link_to [storytime, :dashboard, :api_tokens], class: "storytime-modal-trigger", remote: true, id: "api-tokens-link" do %>
+              <i class="icon-st-icons-settings"></i>
+              <span style="margin-left: 10px; margin-right: 6px;">API Tokens</span>
+            <% end %>
+          </li>
         <% end %>
         <% if Pundit.policy(current_user, Storytime::Subscription).manage? %>
           <li>

--- a/app/views/storytime/dashboard/_navigation.html.erb
+++ b/app/views/storytime/dashboard/_navigation.html.erb
@@ -82,6 +82,11 @@
           <%= link_to "Media", [storytime, :dashboard, Storytime::Media] %>
         </li>
       <% end %>
+      <% if Pundit.policy(current_user, Storytime::Artifact).index? %>
+        <li <%= active_nav_item_class("artifacts") %>>
+          <%= link_to "Artifacts", storytime.dashboard_artifacts_path %>
+        </li>
+      <% end %>
 
       <li <%= active_nav_item_class("pages", Storytime::Page.type_name) %>>
         <%= link_to Storytime::Page.human_name.pluralize, [storytime, :dashboard, Storytime::Page] %>

--- a/app/views/storytime/dashboard/_settings_tabs.html.erb
+++ b/app/views/storytime/dashboard/_settings_tabs.html.erb
@@ -20,6 +20,12 @@
         <span class="hidden-xs">Permissions</span>
       <% end %>
     </li>
+    <li role="presentation" <%= active_nav_item_class("api_tokens") %>>
+      <%= link_to [:dashboard, :api_tokens], remote: true, class: "storytime-modal-trigger" do %>
+        <i class="icon-st-icons-settings"></i>
+        <span class="hidden-xs">API Tokens</span>
+      <% end %>
+    </li>
   <% end %>
   <% if Pundit.policy(current_user, Storytime::Subscription).manage? %>
     <li role="presentation" <%= active_nav_item_class("subscriptions") %>>

--- a/app/views/storytime/dashboard/api_tokens/_api_token.html.erb
+++ b/app/views/storytime/dashboard/api_tokens/_api_token.html.erb
@@ -1,0 +1,18 @@
+<li class="list-group-item" id="apitoken_<%= api_token.id %>">
+  <div class="list-group-actions">
+    <%= delete_resource_link api_token, dashboard_api_token_url(api_token) %>
+  </div>
+  <strong><%= api_token.name %></strong>
+  <p class="text-muted no-margin" style="font-size: 12px;">
+    <code><%= api_token.token_prefix %>…</code>
+    · created <%= api_token.created_at.strftime("%b %-d, %Y") %>
+    <% if api_token.last_used_at %>
+      · last used <%= api_token.last_used_at.strftime("%b %-d, %Y") %>
+    <% else %>
+      · never used
+    <% end %>
+    <% if api_token.expires_at %>
+      · <%= api_token.expired? ? "expired" : "expires" %> <%= api_token.expires_at.strftime("%b %-d, %Y") %>
+    <% end %>
+  </p>
+</li>

--- a/app/views/storytime/dashboard/api_tokens/_index.html.erb
+++ b/app/views/storytime/dashboard/api_tokens/_index.html.erb
@@ -33,8 +33,13 @@
           <%= f.input_field :name, class: "form-control", placeholder: "e.g. Claude Code" %>
         </div>
         <div class="col-xs-4">
-          <label class="control-label small text-muted">Expires <span class="text-muted">(optional)</span></label>
-          <%= f.input_field :expires_at, type: "date", class: "form-control" %>
+          <label class="control-label small text-muted">
+            Expires <span class="text-muted">(optional)</span>
+            <%= link_to "Clear", "#", class: "js-clear-datepicker small", data: { target: "api_token_expires_at" }, style: "margin-left: 6px;" %>
+          </label>
+          <%= f.text_field :expires_at, class: "form-control datepicker", readonly: true,
+                           id: "api_token_expires_at", autocomplete: "off",
+                           placeholder: "No expiration" %>
         </div>
         <div class="col-xs-2">
           <label class="control-label small">&nbsp;</label>

--- a/app/views/storytime/dashboard/api_tokens/_index.html.erb
+++ b/app/views/storytime/dashboard/api_tokens/_index.html.erb
@@ -1,0 +1,51 @@
+<div class="scroll-panel">
+  <div class="scroll-panel-header">
+    <button type="button" class="close pull-left" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <h3 class="scroll-panel-title">API Tokens</h3>
+  </div>
+  <div class="scroll-panel-body">
+
+    <%= render 'storytime/dashboard/settings_tabs' %>
+
+    <input type="hidden" value="<%= params[:controller].camelize %>" id="storytime-modal-controller">
+    <input type="hidden" value="<%= params[:action].camelize %>" id="storytime-modal-action">
+
+    <% if @created_token.present? %>
+      <div class="alert alert-success">
+        <strong>Copy your new token now</strong> &ndash; it won't be shown again.
+        <input type="text" readonly value="<%= @created_token %>" onclick="this.select()"
+               class="form-control" style="font-family: monospace; margin-top: 8px;">
+      </div>
+    <% end %>
+
+    <% if @api_token && @api_token.errors.any? %>
+      <div class="alert alert-danger"><%= @api_token.errors.full_messages.to_sentence %></div>
+    <% end %>
+
+    <p class="text-muted">
+      Use a token as a bearer credential: <code>Authorization: Bearer &lt;token&gt;</code>
+    </p>
+
+    <%= simple_form_for [:dashboard, Storytime::ApiToken.new], remote: true, html: { class: "storytime-modal-form", data: { redirect: "index" } } do |f| %>
+      <div class="row">
+        <div class="col-xs-6">
+          <%= f.input :name, label: false, placeholder: "Name (e.g. Claude Code)", wrapper_html: { class: "no-margin" } %>
+        </div>
+        <div class="col-xs-4">
+          <%= f.input_field :expires_at, as: :string, class: "form-control", input_html: { type: "date" } %>
+        </div>
+        <div class="col-xs-2">
+          <%= f.submit "Create", class: "btn btn-primary btn-outline btn-sm" %>
+        </div>
+      </div>
+    <% end %>
+
+    <ul class="list-group list-group-button-links" style="margin-top: 16px;">
+      <% if @api_tokens.any? %>
+        <%= render partial: "storytime/dashboard/api_tokens/api_token", collection: @api_tokens %>
+      <% else %>
+        <li class="list-group-item text-muted">No API tokens yet.</li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/storytime/dashboard/api_tokens/_index.html.erb
+++ b/app/views/storytime/dashboard/api_tokens/_index.html.erb
@@ -29,13 +29,16 @@
     <%= simple_form_for [:dashboard, Storytime::ApiToken.new], remote: true, html: { class: "storytime-modal-form", data: { redirect: "index" } } do |f| %>
       <div class="row">
         <div class="col-xs-6">
-          <%= f.input :name, label: false, placeholder: "Name (e.g. Claude Code)", wrapper_html: { class: "no-margin" } %>
+          <label class="control-label small text-muted">Name</label>
+          <%= f.input_field :name, class: "form-control", placeholder: "e.g. Claude Code" %>
         </div>
         <div class="col-xs-4">
-          <%= f.input_field :expires_at, as: :string, class: "form-control", input_html: { type: "date" } %>
+          <label class="control-label small text-muted">Expires <span class="text-muted">(optional)</span></label>
+          <%= f.input_field :expires_at, type: "date", class: "form-control" %>
         </div>
         <div class="col-xs-2">
-          <%= f.submit "Create", class: "btn btn-primary btn-outline btn-sm" %>
+          <label class="control-label small">&nbsp;</label>
+          <%= f.submit "Create", class: "btn btn-primary btn-outline btn-sm btn-block" %>
         </div>
       </div>
     <% end %>

--- a/app/views/storytime/dashboard/api_tokens/index.json.jbuilder
+++ b/app/views/storytime/dashboard/api_tokens/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.html(render partial: "storytime/dashboard/api_tokens/index", formats: [:html])

--- a/app/views/storytime/dashboard/artifacts/_artifact.html.erb
+++ b/app/views/storytime/dashboard/artifacts/_artifact.html.erb
@@ -1,0 +1,36 @@
+<tr>
+  <td>
+    <strong><%= artifact.name %></strong>
+    <% if artifact.byte_size.present? %>
+      <br><span class="text-muted" style="font-size: 12px;"><%= number_to_human_size(artifact.byte_size) %></span>
+    <% end %>
+  </td>
+  <td>
+    <% url = artifact_url(artifact.token) %>
+    <input type="text" readonly value="<%= url %>"
+           onclick="this.select()"
+           class="form-control input-sm" style="min-width: 220px; font-family: monospace; font-size: 12px;">
+    <%= link_to "Open", url, target: "_blank", rel: "noopener", style: "font-size: 12px;" %>
+  </td>
+  <td style="font-size: 12px;">
+    <% if artifact.password_protected? %>
+      <span class="label label-warning">Password</span>
+    <% end %>
+    <% if artifact.expires_at.present? %>
+      <br>
+      <span class="<%= artifact.expired? ? "label label-danger" : "text-muted" %>">
+        <%= artifact.expired? ? "Expired" : "Expires" %> <%= artifact.expires_at.strftime("%b %-d, %Y %-l:%M %p") %>
+      </span>
+    <% end %>
+    <% unless artifact.password_protected? || artifact.expires_at.present? %>
+      <span class="text-muted">Anyone with the link</span>
+    <% end %>
+  </td>
+  <td style="font-size: 12px;"><%= artifact.created_at.strftime("%b %-d, %Y") %></td>
+  <td class="text-right">
+    <%= link_to "Edit", edit_dashboard_artifact_path(artifact.token), class: "btn btn-default btn-xs" %>
+    <%= link_to "Delete", dashboard_artifact_path(artifact.token), method: :delete,
+                data: { confirm: "Delete this artifact? The link will stop working." },
+                class: "btn btn-danger btn-xs" %>
+  </td>
+</tr>

--- a/app/views/storytime/dashboard/artifacts/_form.html.erb
+++ b/app/views/storytime/dashboard/artifacts/_form.html.erb
@@ -42,10 +42,15 @@
 
   <div class="form-group">
     <label class="control-label">Expiration <span class="text-muted">(optional)</span></label>
-    <%= f.input_field :expires_at, as: :string, class: "form-control",
-                      input_html: { type: "datetime-local" },
-                      value: @artifact.expires_at&.strftime("%Y-%m-%dT%H:%M") %>
-    <p class="help-block">After this time the link stops working. Leave blank for no expiration.</p>
+    <div>
+      <%= f.text_field :expires_at, class: "form-control datepicker", readonly: true,
+                       id: "artifact_expires_at", autocomplete: "off",
+                       placeholder: "No expiration",
+                       value: @artifact.expires_at&.strftime("%B %-d, %Y"),
+                       style: "display: inline-block; width: auto;" %>
+      <%= link_to "Clear", "#", class: "js-clear-datepicker", data: { target: "artifact_expires_at" } %>
+    </div>
+    <p class="help-block">The link stops working at the end of this day. Leave blank for no expiration.</p>
   </div>
 
   <div style="margin-top: 20px;">

--- a/app/views/storytime/dashboard/artifacts/_form.html.erb
+++ b/app/views/storytime/dashboard/artifacts/_form.html.erb
@@ -1,0 +1,55 @@
+<%= simple_form_for [:dashboard, @artifact], html: { multipart: true } do |f| %>
+  <%= f.error_notification %>
+  <% if @artifact.errors.any? %>
+    <div class="alert alert-danger">
+      <ul style="margin: 0; padding-left: 18px;">
+        <% @artifact.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.input :name, label: "Name", hint: "Shown only in this dashboard.", input_html: { class: "form-control" } %>
+
+  <div class="form-group">
+    <label class="control-label">
+      <%= @artifact.persisted? ? "Replace HTML file" : "HTML file" %>
+    </label>
+    <%= f.file_field :file, accept: "text/html,.html,.htm" %>
+    <% if @artifact.persisted? %>
+      <p class="help-block">
+        Leave blank to keep the current file<%= @artifact.original_filename.present? ? " (#{@artifact.original_filename})" : "" %>.
+      </p>
+    <% else %>
+      <p class="help-block">Upload a single self-contained <code>.html</code> file (CSS, JS, and images inlined).</p>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label">Password <span class="text-muted">(optional)</span></label>
+    <%= f.password_field :password, class: "form-control", autocomplete: "new-password",
+                         placeholder: @artifact.password_protected? ? "•••••••• (set — leave blank to keep)" : "No password" %>
+    <% if @artifact.password_protected? %>
+      <div class="checkbox">
+        <label>
+          <%= check_box_tag "artifact[remove_password]", "1", false %> Remove password protection
+        </label>
+      </div>
+    <% end %>
+    <p class="help-block">When set, viewers must enter this password. It is remembered for their session.</p>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label">Expiration <span class="text-muted">(optional)</span></label>
+    <%= f.input_field :expires_at, as: :string, class: "form-control",
+                      input_html: { type: "datetime-local" },
+                      value: @artifact.expires_at&.strftime("%Y-%m-%dT%H:%M") %>
+    <p class="help-block">After this time the link stops working. Leave blank for no expiration.</p>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.button :submit, @artifact.persisted? ? "Save Changes" : "Create Artifact", class: "btn btn-primary" %>
+    <%= link_to "Cancel", dashboard_artifacts_path, class: "btn btn-default" %>
+  </div>
+<% end %>

--- a/app/views/storytime/dashboard/artifacts/edit.html.erb
+++ b/app/views/storytime/dashboard/artifacts/edit.html.erb
@@ -1,0 +1,19 @@
+<div id="main">
+  <div class="scroll-panel">
+    <div class="scroll-panel-header">
+      <div class="pull-left">
+        <%= link_to dashboard_artifacts_path, class: "btn btn-default btn-scroll-panel-header" do %>
+          <%= icon('angle-left') %>
+          <span class="hidden-xs">Artifacts</span>
+        <% end %>
+      </div>
+      <h3 class="scroll-panel-title">Edit Artifact</h3>
+      <div class="pull-right">
+        <%= link_to "Open", artifact_url(@artifact.token), target: "_blank", rel: "noopener", class: "btn btn-default btn-sm" %>
+      </div>
+    </div>
+    <div class="scroll-panel-body">
+      <%= render "form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/storytime/dashboard/artifacts/index.html.erb
+++ b/app/views/storytime/dashboard/artifacts/index.html.erb
@@ -1,15 +1,15 @@
 <div id="main">
   <div class="scroll-panel">
     <div class="scroll-panel-header">
-      <div class="pull-left">
-        <%= link_to "#", class: "btn btn-default btn-icon", data: { toggle: "off-canvas", target: "#dashboard-nav" } do %>
-          <i class="icon-st-icons-st-logo"></i>
-        <% end %>
-      </div>
-      <h3 class="scroll-panel-title">Artifacts</h3>
+      <%= link_to "#", class: "btn btn-default btn-icon pull-left visible-xs visible-sm", data: { toggle: "off-canvas", target: "#dashboard-nav" } do %>
+        <i class="icon-st-icons-st-logo"></i>
+      <% end %>
+
       <div class="pull-right">
         <%= link_to "New Artifact", new_dashboard_artifact_path, class: "btn btn-primary btn-outline btn-sm" %>
       </div>
+
+      <h3 class="scroll-panel-title">Artifacts</h3>
     </div>
 
     <div class="scroll-panel-body">

--- a/app/views/storytime/dashboard/artifacts/index.html.erb
+++ b/app/views/storytime/dashboard/artifacts/index.html.erb
@@ -1,0 +1,40 @@
+<div id="main">
+  <div class="scroll-panel">
+    <div class="scroll-panel-header">
+      <div class="pull-left">
+        <%= link_to "#", class: "btn btn-default btn-icon", data: { toggle: "off-canvas", target: "#dashboard-nav" } do %>
+          <i class="icon-st-icons-st-logo"></i>
+        <% end %>
+      </div>
+      <h3 class="scroll-panel-title">Artifacts</h3>
+      <div class="pull-right">
+        <%= link_to "New Artifact", new_dashboard_artifact_path, class: "btn btn-primary btn-outline btn-sm" %>
+      </div>
+    </div>
+
+    <div class="scroll-panel-body">
+      <% if @artifacts.any? %>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Link</th>
+              <th>Access</th>
+              <th>Created</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render partial: "artifact", collection: @artifacts %>
+          </tbody>
+        </table>
+
+        <%= paginate @artifacts %>
+      <% else %>
+        <p class="text-muted" style="padding: 20px 0;">
+          No artifacts yet. <%= link_to "Create your first one", new_dashboard_artifact_path %>.
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/storytime/dashboard/artifacts/new.html.erb
+++ b/app/views/storytime/dashboard/artifacts/new.html.erb
@@ -1,0 +1,16 @@
+<div id="main">
+  <div class="scroll-panel">
+    <div class="scroll-panel-header">
+      <div class="pull-left">
+        <%= link_to dashboard_artifacts_path, class: "btn btn-default btn-scroll-panel-header" do %>
+          <%= icon('angle-left') %>
+          <span class="hidden-xs">Artifacts</span>
+        <% end %>
+      </div>
+      <h3 class="scroll-panel-title">New Artifact</h3>
+    </div>
+    <div class="scroll-panel-body">
+      <%= render "form" %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Storytime::Engine.routes.draw do
     end
     resources :snippets, except: [:show]
     resources :media, except: [:show, :edit, :update]
+    resources :artifacts, except: [:show]
     resources :imports, only: [:new, :create]
     resources :subscriptions
     resources :memberships
@@ -48,6 +49,17 @@ Storytime::Engine.routes.draw do
       end
     end
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :artifacts, only: [:index, :show, :create, :update, :destroy], param: :token
+    end
+  end
+
+  # Public, token-addressed artifact serving. Registered before the catch-all
+  # pages route below so it is matched first.
+  get "/a/:token", to: "artifacts#show", as: :artifact
+  post "/a/:token/unlock", to: "artifacts#unlock", as: :unlock_artifact
 
   get "/", to: "blog_homepage#show", constraints: Storytime::Constraints::BlogHomepageConstraint.new
   get "/", to: "homepage#show", constraints: Storytime::Constraints::PageHomepageConstraint.new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Storytime::Engine.routes.draw do
     resources :snippets, except: [:show]
     resources :media, except: [:show, :edit, :update]
     resources :artifacts, except: [:show]
+    resources :api_tokens, only: [:index, :create, :destroy]
     resources :imports, only: [:new, :create]
     resources :subscriptions
     resources :memberships

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Storytime::Engine.routes.draw do
   # Public, token-addressed artifact serving. Registered before the catch-all
   # pages route below so it is matched first.
   get "/a/:token", to: "artifacts#show", as: :artifact
+  get "/a/:token/raw", to: "artifacts#raw", as: :raw_artifact
   post "/a/:token/unlock", to: "artifacts#unlock", as: :unlock_artifact
 
   get "/", to: "blog_homepage#show", constraints: Storytime::Constraints::BlogHomepageConstraint.new

--- a/db/migrate/20260707120000_create_storytime_artifacts.rb
+++ b/db/migrate/20260707120000_create_storytime_artifacts.rb
@@ -1,0 +1,22 @@
+class CreateStorytimeArtifacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :storytime_artifacts do |t|
+      t.integer :site_id
+      t.integer :user_id
+      t.string :name, null: false
+      t.string :token, null: false
+      t.text :content
+      t.string :content_type, default: "text/html"
+      t.bigint :byte_size
+      t.string :original_filename
+      t.string :password_digest
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+
+    add_index :storytime_artifacts, :token, unique: true
+    add_index :storytime_artifacts, :site_id
+    add_index :storytime_artifacts, :expires_at
+  end
+end

--- a/db/migrate/20260707130000_create_storytime_api_tokens.rb
+++ b/db/migrate/20260707130000_create_storytime_api_tokens.rb
@@ -1,0 +1,18 @@
+class CreateStorytimeApiTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :storytime_api_tokens do |t|
+      t.integer :site_id
+      t.integer :user_id
+      t.string :name, null: false
+      t.string :token_digest, null: false
+      t.string :token_prefix
+      t.datetime :last_used_at
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+
+    add_index :storytime_api_tokens, :token_digest, unique: true
+    add_index :storytime_api_tokens, :site_id
+  end
+end

--- a/lib/storytime.rb
+++ b/lib/storytime.rb
@@ -108,6 +108,11 @@ module Storytime
   mattr_accessor :aws_secret_key
   @@aws_secret_key = ENV['STORYTIME_AWS_SECRET_KEY']
 
+  # Bearer token used to authenticate the Artifacts API. When blank the API is
+  # effectively disabled (all requests are rejected as unauthorized).
+  mattr_accessor :artifacts_api_token
+  @@artifacts_api_token = ENV['STORYTIME_ARTIFACTS_API_TOKEN']
+
   # Superclass for Storytime::ApplicationController
   # Defaults to the host app's ApplicationController
   mattr_accessor :application_controller_superclass

--- a/lib/storytime.rb
+++ b/lib/storytime.rb
@@ -108,11 +108,6 @@ module Storytime
   mattr_accessor :aws_secret_key
   @@aws_secret_key = ENV['STORYTIME_AWS_SECRET_KEY']
 
-  # Bearer token used to authenticate the Artifacts API. When blank the API is
-  # effectively disabled (all requests are rejected as unauthorized).
-  mattr_accessor :artifacts_api_token
-  @@artifacts_api_token = ENV['STORYTIME_ARTIFACTS_API_TOKEN']
-
   # Superclass for Storytime::ApplicationController
   # Defaults to the host app's ApplicationController
   mattr_accessor :application_controller_superclass

--- a/lib/storytime/engine.rb
+++ b/lib/storytime/engine.rb
@@ -36,6 +36,12 @@ module Storytime
 
     config.assets.precompile += %w( storytime/storytime-logo-nav.png )
 
+    # Keep API tokens and passwords out of request logs in the host app. Rails
+    # never logs the Authorization header, but this covers any stray param.
+    initializer "storytime.filter_parameters" do |app|
+      app.config.filter_parameters += [:api_token, :password]
+    end
+
     initializer "storytime.view_helpers" do
       ActiveSupport.on_load(:action_view) do
         include Storytime::StorytimeHelpers

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,6 +32,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_120000) do
     t.string "name"
     t.datetime "updated_at", precision: nil
     t.index ["guid"], name: "index_storytime_actions_on_guid"
+  end
+
+  create_table "storytime_api_tokens", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.datetime "last_used_at"
+    t.string "name", null: false
+    t.integer "site_id"
+    t.string "token_digest", null: false
+    t.string "token_prefix"
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["site_id"], name: "index_storytime_api_tokens_on_site_id"
+    t.index ["token_digest"], name: "index_storytime_api_tokens_on_token_digest", unique: true
   end
 
   create_table "storytime_artifacts", force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,6 +32,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_000000) do
     t.string "name"
     t.datetime "updated_at", precision: nil
     t.index ["guid"], name: "index_storytime_actions_on_guid"
+  end
+
+  create_table "storytime_artifacts", force: :cascade do |t|
+    t.bigint "byte_size"
+    t.text "content"
+    t.string "content_type", default: "text/html"
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.string "name", null: false
+    t.string "original_filename"
+    t.string "password_digest"
+    t.integer "site_id"
+    t.string "token", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["expires_at"], name: "index_storytime_artifacts_on_expires_at"
+    t.index ["site_id"], name: "index_storytime_artifacts_on_site_id"
+    t.index ["token"], name: "index_storytime_artifacts_on_token", unique: true
   end
 
   create_table "storytime_autosaves", id: :serial, force: :cascade do |t|

--- a/spec/factories/api_token_factories.rb
+++ b/spec/factories/api_token_factories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :api_token, class: Storytime::ApiToken do
+    user
+    sequence(:name) { |i| "Token #{i}" }
+  end
+end

--- a/spec/factories/artifact_factories.rb
+++ b/spec/factories/artifact_factories.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :artifact, class: Storytime::Artifact do
+    user
+    name { "Test Artifact" }
+    content { "<!DOCTYPE html><html><body><h1>Hello artifact</h1></body></html>" }
+  end
+end

--- a/spec/features/dashboard/artifacts_spec.rb
+++ b/spec/features/dashboard/artifacts_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe "In the dashboard, Artifacts", type: :feature do
+  let(:sample_html) { File.expand_path("../../../support/files/sample_artifact.html", __FILE__) }
+
+  before do
+    login_admin
+  end
+
+  it "shows an empty state when there are no artifacts" do
+    visit storytime.dashboard_artifacts_path
+    expect(page).to have_content("No artifacts yet")
+  end
+
+  it "creates an artifact by uploading an HTML file" do
+    visit storytime.dashboard_artifacts_path
+    click_link "New Artifact"
+
+    fill_in "artifact_name", with: "Release Notes"
+    attach_file "artifact_file", sample_html
+    click_button "Create Artifact"
+
+    expect(page).to have_content("Artifact created.")
+    expect(page).to have_content("Release Notes")
+
+    artifact = Storytime::Artifact.find_by(name: "Release Notes")
+    expect(artifact).to be_present
+    expect(artifact.content).to include("Sample artifact body")
+    expect(artifact.byte_size).to be > 0
+  end
+
+  it "creates a password-protected, expiring artifact" do
+    visit storytime.new_dashboard_artifact_path
+
+    fill_in "artifact_name", with: "Gated"
+    attach_file "artifact_file", sample_html
+    fill_in "artifact_password", with: "hunter2"
+    click_button "Create Artifact"
+
+    expect(page).to have_content("Artifact created.")
+    artifact = Storytime::Artifact.find_by(name: "Gated")
+    expect(artifact).to be_password_protected
+  end
+
+  it "removes password protection from an existing artifact" do
+    artifact = FactoryBot.create(:artifact, site: @current_site, user: current_user,
+                                 name: "Was Gated", password: "hunter2")
+
+    visit storytime.edit_dashboard_artifact_path(artifact.token)
+    check "artifact_remove_password"
+    click_button "Save Changes"
+
+    expect(page).to have_content("Artifact updated.")
+    expect(artifact.reload).not_to be_password_protected
+  end
+
+  it "edits an artifact's name" do
+    artifact = FactoryBot.create(:artifact, site: @current_site, user: current_user, name: "Old Name")
+
+    visit storytime.edit_dashboard_artifact_path(artifact.token)
+    fill_in "artifact_name", with: "New Name"
+    click_button "Save Changes"
+
+    expect(page).to have_content("Artifact updated.")
+    expect(artifact.reload.name).to eq("New Name")
+  end
+
+  it "deletes an artifact" do
+    artifact = FactoryBot.create(:artifact, site: @current_site, user: current_user, name: "Doomed")
+
+    visit storytime.dashboard_artifacts_path
+    expect(page).to have_content("Doomed")
+
+    click_link "Delete"
+
+    expect(page).to have_content("Artifact deleted.")
+    expect(Storytime::Artifact.find_by(token: artifact.token)).to be_nil
+  end
+end

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -11,9 +11,9 @@ module Storytime
     end
 
     describe "token generation" do
-      it "exposes the raw token once, prefixed with sk_" do
+      it "exposes the raw token once, prefixed with sk_stime_" do
         token = FactoryBot.create(:api_token)
-        expect(token.raw_token).to start_with("sk_")
+        expect(token.raw_token).to start_with("sk_stime_")
         expect(token.raw_token.length).to be >= 40
       end
 
@@ -26,9 +26,10 @@ module Storytime
         expect(Storytime::ApiToken.find(token.id).raw_token).to be_nil
       end
 
-      it "records a display prefix" do
+      it "records a display prefix including the source prefix" do
         token = FactoryBot.create(:api_token)
-        expect(token.token_prefix).to eq(token.raw_token[0, 11])
+        expect(token.token_prefix).to start_with("sk_stime_")
+        expect(token.token_prefix).to eq(token.raw_token[0, Storytime::ApiToken::PREFIX.length + 6])
       end
     end
 

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+module Storytime
+  describe ApiToken, type: :model do
+    it "is valid with a name" do
+      expect(FactoryBot.build(:api_token, name: "CI")).to be_valid
+    end
+
+    it "requires a name" do
+      expect(FactoryBot.build(:api_token, name: nil)).not_to be_valid
+    end
+
+    describe "token generation" do
+      it "exposes the raw token once, prefixed with sk_" do
+        token = FactoryBot.create(:api_token)
+        expect(token.raw_token).to start_with("sk_")
+        expect(token.raw_token.length).to be >= 40
+      end
+
+      it "stores only a digest, never the raw token" do
+        token = FactoryBot.create(:api_token)
+        raw = token.raw_token
+        expect(token.token_digest).to eq(Storytime::ApiToken.digest(raw))
+        expect(token.token_digest).not_to eq(raw)
+        # reloading does not resurface the raw token
+        expect(Storytime::ApiToken.find(token.id).raw_token).to be_nil
+      end
+
+      it "records a display prefix" do
+        token = FactoryBot.create(:api_token)
+        expect(token.token_prefix).to eq(token.raw_token[0, 11])
+      end
+    end
+
+    describe ".authenticate" do
+      it "returns the token for the correct raw value" do
+        token = FactoryBot.create(:api_token)
+        expect(Storytime::ApiToken.authenticate(token.raw_token)).to eq(token)
+      end
+
+      it "returns nil for an unknown value" do
+        FactoryBot.create(:api_token)
+        expect(Storytime::ApiToken.authenticate("sk_nope")).to be_nil
+      end
+
+      it "returns nil for a blank value" do
+        expect(Storytime::ApiToken.authenticate("")).to be_nil
+        expect(Storytime::ApiToken.authenticate(nil)).to be_nil
+      end
+
+      it "returns nil for an expired token" do
+        token = FactoryBot.create(:api_token, expires_at: 1.hour.ago)
+        expect(Storytime::ApiToken.authenticate(token.raw_token)).to be_nil
+      end
+
+      it "authenticates regardless of the current site scope" do
+        site_a = FactoryBot.create(:site)
+        token = nil
+        Storytime::Site.current_id = site_a.id
+        begin
+          token = FactoryBot.create(:api_token, site: site_a)
+        ensure
+          Storytime::Site.current_id = nil
+        end
+        expect(Storytime::ApiToken.authenticate(token.raw_token)).to eq(token)
+      end
+    end
+
+    describe "#touch_last_used!" do
+      it "stamps last_used_at" do
+        token = FactoryBot.create(:api_token, last_used_at: nil)
+        token.touch_last_used!
+        expect(token.reload.last_used_at).to be_present
+      end
+    end
+  end
+end

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -17,10 +17,11 @@ module Storytime
     end
 
     describe "token" do
-      it "generates a long unguessable token on create" do
+      it "generates a long unguessable alphanumeric token on create" do
         artifact = FactoryBot.create(:artifact)
         expect(artifact.token).to be_present
         expect(artifact.token.length).to be >= 30
+        expect(artifact.token).to match(/\A[A-Za-z0-9]+\z/)
       end
 
       it "does not overwrite an existing token" do

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -16,6 +16,13 @@ module Storytime
       expect(artifact).not_to be_valid
     end
 
+    it "rejects content larger than the size limit" do
+      oversized = "a" * (Artifact::MAX_CONTENT_BYTES + 1)
+      artifact = FactoryBot.build(:artifact, content: oversized)
+      expect(artifact).not_to be_valid
+      expect(artifact.errors[:content].join).to match(/too large/)
+    end
+
     describe "token" do
       it "generates a long unguessable alphanumeric token on create" do
         artifact = FactoryBot.create(:artifact)

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+module Storytime
+  describe Artifact, type: :model do
+    it "is valid with a name and content" do
+      expect(FactoryBot.build(:artifact)).to be_valid
+    end
+
+    it "requires a name" do
+      artifact = FactoryBot.build(:artifact, name: nil)
+      expect(artifact).not_to be_valid
+    end
+
+    it "requires content" do
+      artifact = FactoryBot.build(:artifact, content: nil)
+      expect(artifact).not_to be_valid
+    end
+
+    describe "token" do
+      it "generates a long unguessable token on create" do
+        artifact = FactoryBot.create(:artifact)
+        expect(artifact.token).to be_present
+        expect(artifact.token.length).to be >= 30
+      end
+
+      it "does not overwrite an existing token" do
+        artifact = FactoryBot.create(:artifact, token: "my-custom-token")
+        expect(artifact.token).to eq("my-custom-token")
+      end
+
+      it "uses the token as the param" do
+        artifact = FactoryBot.create(:artifact)
+        expect(artifact.to_param).to eq(artifact.token)
+      end
+    end
+
+    describe "#assign_html" do
+      it "stores a raw string and records byte size" do
+        artifact = Artifact.new(name: "x")
+        artifact.assign_html("<html>hi</html>", filename: "page.html")
+        expect(artifact.content).to eq("<html>hi</html>")
+        expect(artifact.byte_size).to eq("<html>hi</html>".bytesize)
+        expect(artifact.content_type).to eq("text/html")
+        expect(artifact.original_filename).to eq("page.html")
+      end
+
+      it "reads from an IO-like object" do
+        artifact = Artifact.new(name: "x")
+        artifact.assign_html(StringIO.new("<html>io</html>"))
+        expect(artifact.content).to eq("<html>io</html>")
+      end
+    end
+
+    describe "password protection" do
+      it "is not protected without a password" do
+        expect(FactoryBot.create(:artifact)).not_to be_password_protected
+      end
+
+      it "is protected and authenticates once a password is set" do
+        artifact = FactoryBot.create(:artifact, password: "secret")
+        expect(artifact).to be_password_protected
+        expect(artifact.authenticate("secret")).to be_truthy
+        expect(artifact.authenticate("wrong")).to be_falsey
+      end
+    end
+
+    describe "expiration" do
+      it "is not expired when expires_at is nil" do
+        expect(FactoryBot.create(:artifact, expires_at: nil)).not_to be_expired
+      end
+
+      it "is expired when expires_at is in the past" do
+        expect(FactoryBot.create(:artifact, expires_at: 1.hour.ago)).to be_expired
+      end
+
+      it "is not expired when expires_at is in the future" do
+        expect(FactoryBot.create(:artifact, expires_at: 1.hour.from_now)).not_to be_expired
+      end
+
+      it "excludes expired records from the active scope" do
+        active = FactoryBot.create(:artifact)
+        future = FactoryBot.create(:artifact, expires_at: 1.hour.from_now)
+        FactoryBot.create(:artifact, expires_at: 1.hour.ago)
+        expect(Artifact.active).to match_array([active, future])
+      end
+    end
+  end
+end

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -57,6 +57,17 @@ module Storytime
         artifact.assign_html(StringIO.new("<html>io</html>"))
         expect(artifact.content).to eq("<html>io</html>")
       end
+
+      it "scrubs invalid byte sequences into valid UTF-8 so it saves cleanly" do
+        # 0xE9 is a lone Latin-1 'é' byte, invalid as UTF-8.
+        artifact = FactoryBot.build(:artifact, content: nil)
+        artifact.assign_html("<html>caf\xE9</html>".b)
+
+        expect(artifact.content.encoding).to eq(Encoding::UTF_8)
+        expect(artifact.content).to be_valid_encoding
+        expect(artifact.byte_size).to eq(artifact.content.bytesize)
+        expect(artifact.save).to be(true)
+      end
     end
 
     describe "password protection" do

--- a/spec/requests/api_artifacts_spec.rb
+++ b/spec/requests/api_artifacts_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe "Artifacts API", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:site) do
+    s = FactoryBot.create(:site, custom_domain: "www.example.com")
+    s.save_with_seeds(user)
+    s
+  end
+
+  let(:api_token) { "test-api-token" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{api_token}" } }
+
+  around do |example|
+    original = Storytime.artifacts_api_token
+    Storytime.artifacts_api_token = api_token
+    example.run
+    Storytime.artifacts_api_token = original
+  end
+
+  describe "authentication" do
+    it "rejects requests without a valid token" do
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "X", html: "<html>hi</html>" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "rejects requests with the wrong token" do
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "X", html: "<html>hi</html>" },
+           headers: { "Authorization" => "Bearer nope" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /api/v1/artifacts" do
+    it "creates an artifact from raw html and returns the token url" do
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "From API", html: "<html>api body</html>", password: "pw", expires_at: 1.day.from_now.iso8601 },
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json["token"]).to be_present
+      expect(json["url"]).to include("/a/#{json['token']}")
+      expect(json["password_protected"]).to eq(true)
+
+      artifact = Storytime::Artifact.find_by(token: json["token"])
+      expect(artifact.content).to eq("<html>api body</html>")
+      expect(artifact.authenticate("pw")).to be_truthy
+    end
+
+    it "returns errors when content is missing" do
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "No content" },
+           headers: auth_headers
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "PATCH /api/v1/artifacts/:token" do
+    it "replaces the content" do
+      artifact = FactoryBot.create(:artifact, site: site, user: user, content: "<html>old</html>")
+
+      patch "http://www.example.com/api/v1/artifacts/#{artifact.token}",
+            params: { html: "<html>new</html>" },
+            headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(artifact.reload.content).to eq("<html>new</html>")
+    end
+  end
+
+  describe "DELETE /api/v1/artifacts/:token" do
+    it "deletes the artifact" do
+      artifact = FactoryBot.create(:artifact, site: site, user: user)
+
+      delete "http://www.example.com/api/v1/artifacts/#{artifact.token}", headers: auth_headers
+
+      expect(response).to have_http_status(:no_content)
+      expect(Storytime::Artifact.find_by(token: artifact.token)).to be_nil
+    end
+  end
+end

--- a/spec/requests/api_artifacts_spec.rb
+++ b/spec/requests/api_artifacts_spec.rb
@@ -25,6 +25,40 @@ describe "Artifacts API", type: :request do
            headers: { "Authorization" => "Bearer nope" }
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "does not accept the token from a query parameter (header only)" do
+      post "http://www.example.com/api/v1/artifacts?api_token=#{raw_token}",
+           params: { name: "X", html: "<html>hi</html>" }
+      expect(response).to have_http_status(:unauthorized)
+      expect(Storytime::Artifact.unscoped.where(name: "X")).to be_empty
+    end
+
+    it "rejects a valid token minted for a different site" do
+      other_site = FactoryBot.create(:site, custom_domain: "other.example.com")
+      other_site.save_with_seeds(FactoryBot.create(:user))
+      other_token = FactoryBot.create(:api_token, site: other_site, user: user)
+
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "Cross", html: "<html>x</html>" },
+           headers: { "Authorization" => "Bearer #{other_token.raw_token}" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(Storytime::Artifact.unscoped.where(name: "Cross")).to be_empty
+    end
+
+    it "rejects a token whose owner lacks artifact-manage rights on the site" do
+      writer = FactoryBot.create(:user)
+      Storytime::Membership.create!(user: writer, site: site,
+                                    storytime_role: Storytime::Role.find_by(name: "writer"))
+      writer_token = FactoryBot.create(:api_token, site: site, user: writer)
+
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "ByWriter", html: "<html>x</html>" },
+           headers: { "Authorization" => "Bearer #{writer_token.raw_token}" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(Storytime::Artifact.unscoped.where(name: "ByWriter")).to be_empty
+    end
   end
 
   describe "POST /api/v1/artifacts" do

--- a/spec/requests/api_artifacts_spec.rb
+++ b/spec/requests/api_artifacts_spec.rb
@@ -8,15 +8,9 @@ describe "Artifacts API", type: :request do
     s
   end
 
-  let(:api_token) { "test-api-token" }
-  let(:auth_headers) { { "Authorization" => "Bearer #{api_token}" } }
-
-  around do |example|
-    original = Storytime.artifacts_api_token
-    Storytime.artifacts_api_token = api_token
-    example.run
-    Storytime.artifacts_api_token = original
-  end
+  let!(:token_record) { FactoryBot.create(:api_token, site: site, user: user) }
+  let(:raw_token) { token_record.raw_token }
+  let(:auth_headers) { { "Authorization" => "Bearer #{raw_token}" } }
 
   describe "authentication" do
     it "rejects requests without a valid token" do
@@ -48,6 +42,14 @@ describe "Artifacts API", type: :request do
       artifact = Storytime::Artifact.find_by(token: json["token"])
       expect(artifact.content).to eq("<html>api body</html>")
       expect(artifact.authenticate("pw")).to be_truthy
+      expect(artifact.user).to eq(user)
+    end
+
+    it "stamps the token's last_used_at" do
+      post "http://www.example.com/api/v1/artifacts",
+           params: { name: "X", html: "<html>hi</html>" },
+           headers: auth_headers
+      expect(token_record.reload.last_used_at).to be_present
     end
 
     it "returns errors when content is missing" do

--- a/spec/requests/artifacts_spec.rb
+++ b/spec/requests/artifacts_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe "Artifacts (public serving)", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:site) do
+    s = FactoryBot.create(:site, custom_domain: "www.example.com")
+    s.save_with_seeds(user)
+    s
+  end
+
+  def create_artifact(**attrs)
+    FactoryBot.create(:artifact, { site: site, user: user }.merge(attrs))
+  end
+
+  describe "GET /a/:token" do
+    it "serves the artifact HTML with a noindex header" do
+      artifact = create_artifact(content: "<html><body>Live artifact</body></html>")
+
+      get "http://www.example.com/a/#{artifact.token}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Live artifact")
+      expect(response.media_type).to eq("text/html")
+      expect(response.headers["X-Robots-Tag"]).to include("noindex")
+    end
+
+    it "404s for an unknown token" do
+      get "http://www.example.com/a/does-not-exist"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s for an expired artifact" do
+      artifact = create_artifact(expires_at: 1.hour.ago)
+      get "http://www.example.com/a/#{artifact.token}"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "password gating" do
+    it "shows the password form instead of the content when locked" do
+      artifact = create_artifact(content: "<html>secret content</html>", password: "letmein")
+
+      get "http://www.example.com/a/#{artifact.token}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Password required")
+      expect(response.body).not_to include("secret content")
+    end
+
+    it "rejects an incorrect password" do
+      artifact = create_artifact(password: "letmein")
+
+      post "http://www.example.com/a/#{artifact.token}/unlock", params: { password: "wrong" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to include("Incorrect password")
+    end
+
+    it "unlocks for the session with the correct password" do
+      artifact = create_artifact(content: "<html>secret content</html>", password: "letmein")
+
+      post "http://www.example.com/a/#{artifact.token}/unlock", params: { password: "letmein" }
+      expect(response).to redirect_to("/a/#{artifact.token}")
+
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("secret content")
+    end
+  end
+end

--- a/spec/requests/artifacts_spec.rb
+++ b/spec/requests/artifacts_spec.rb
@@ -66,5 +66,20 @@ describe "Artifacts (public serving)", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("secret content")
     end
+
+    it "revokes an existing session unlock when the password changes" do
+      artifact = create_artifact(content: "<html>secret content</html>", password: "letmein")
+
+      post "http://www.example.com/a/#{artifact.token}/unlock", params: { password: "letmein" }
+      get "http://www.example.com/a/#{artifact.token}"
+      expect(response.body).to include("secret content")
+
+      # Rotate the password; the earlier session unlock must no longer apply.
+      artifact.update!(password: "newsecret")
+
+      get "http://www.example.com/a/#{artifact.token}"
+      expect(response.body).to include("Password required")
+      expect(response.body).not_to include("secret content")
+    end
   end
 end

--- a/spec/requests/artifacts_spec.rb
+++ b/spec/requests/artifacts_spec.rb
@@ -13,14 +13,19 @@ describe "Artifacts (public serving)", type: :request do
   end
 
   describe "GET /a/:token" do
-    it "serves the artifact HTML with a noindex header" do
+    it "serves a sandboxed iframe wrapper, not the raw content, with a noindex header" do
       artifact = create_artifact(content: "<html><body>Live artifact</body></html>")
 
       get "http://www.example.com/a/#{artifact.token}"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Live artifact")
-      expect(response.media_type).to eq("text/html")
+      # The wrapper embeds the content in a sandbox WITHOUT allow-same-origin.
+      expect(response.body).to include("iframe")
+      expect(response.body).to include("/a/#{artifact.token}/raw")
+      expect(response.body).to match(/sandbox="[^"]*allow-scripts/)
+      expect(response.body).not_to include('allow-same-origin')
+      # The artifact markup is not inlined on the app origin.
+      expect(response.body).not_to include("Live artifact")
       expect(response.headers["X-Robots-Tag"]).to include("noindex")
     end
 
@@ -33,6 +38,31 @@ describe "Artifacts (public serving)", type: :request do
       artifact = create_artifact(expires_at: 1.hour.ago)
       get "http://www.example.com/a/#{artifact.token}"
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /a/:token/raw" do
+    it "serves the artifact HTML with sandbox and hardening headers" do
+      artifact = create_artifact(content: "<html><body>Live artifact</body></html>")
+
+      get "http://www.example.com/a/#{artifact.token}/raw"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Live artifact")
+      expect(response.media_type).to eq("text/html")
+      expect(response.headers["Content-Security-Policy"]).to match(/\Asandbox .*allow-scripts/)
+      expect(response.headers["Content-Security-Policy"]).not_to include("allow-same-origin")
+      expect(response.headers["X-Content-Type-Options"]).to eq("nosniff")
+      expect(response.headers["X-Robots-Tag"]).to include("noindex")
+    end
+
+    it "404s the raw content while the artifact is still locked" do
+      artifact = create_artifact(content: "<html>secret content</html>", password: "letmein")
+
+      get "http://www.example.com/a/#{artifact.token}/raw"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include("secret content")
     end
   end
 
@@ -64,14 +94,36 @@ describe "Artifacts (public serving)", type: :request do
 
       follow_redirect!
       expect(response).to have_http_status(:ok)
+      # The wrapper now renders; the content is reachable via the raw endpoint.
+      expect(response.body).to include("iframe")
+
+      get "http://www.example.com/a/#{artifact.token}/raw"
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include("secret content")
+    end
+
+    it "throttles repeated incorrect password attempts" do
+      # Use a real cache store so the attempt counter persists across requests,
+      # regardless of the host app's configured cache.
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      artifact = create_artifact(password: "letmein")
+
+      Storytime::ArtifactsController::MAX_UNLOCK_ATTEMPTS.times do
+        post "http://www.example.com/a/#{artifact.token}/unlock", params: { password: "wrong" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      # Further attempts are refused even with the correct password.
+      post "http://www.example.com/a/#{artifact.token}/unlock", params: { password: "letmein" }
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include("Too many attempts")
     end
 
     it "revokes an existing session unlock when the password changes" do
       artifact = create_artifact(content: "<html>secret content</html>", password: "letmein")
 
       post "http://www.example.com/a/#{artifact.token}/unlock", params: { password: "letmein" }
-      get "http://www.example.com/a/#{artifact.token}"
+      get "http://www.example.com/a/#{artifact.token}/raw"
       expect(response.body).to include("secret content")
 
       # Rotate the password; the earlier session unlock must no longer apply.
@@ -79,6 +131,9 @@ describe "Artifacts (public serving)", type: :request do
 
       get "http://www.example.com/a/#{artifact.token}"
       expect(response.body).to include("Password required")
+
+      get "http://www.example.com/a/#{artifact.token}/raw"
+      expect(response).to have_http_status(:not_found)
       expect(response.body).not_to include("secret content")
     end
   end

--- a/spec/requests/dashboard_api_tokens_spec.rb
+++ b/spec/requests/dashboard_api_tokens_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe "Dashboard API tokens", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:site) do
+    s = FactoryBot.create(:site, custom_domain: "www.example.com")
+    s.save_with_seeds(user)
+    s
+  end
+
+  let(:host) { "http://www.example.com" }
+
+  before { sign_in user }
+
+  describe "GET index" do
+    it "lists existing tokens" do
+      FactoryBot.create(:api_token, site: site, user: user, name: "Existing Token")
+
+      get host + dashboard_api_tokens_path(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Existing Token")
+    end
+  end
+
+  describe "POST create" do
+    it "creates a token and surfaces the raw value once" do
+      expect {
+        post host + dashboard_api_tokens_path(format: :json),
+             params: { api_token: { name: "New Token" } }
+      }.to change(Storytime::ApiToken, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      token = Storytime::ApiToken.order(:created_at).last
+      expect(token.user).to eq(user)
+      expect(token.name).to eq("New Token")
+      # The raw token is rendered once in the returned HTML (we can only assert
+      # on the stored prefix, since the full raw value is never persisted).
+      expect(response.body).to include(token.token_prefix)
+      expect(response.body).to include("Copy your new token now")
+    end
+
+    it "rejects a blank name" do
+      post host + dashboard_api_tokens_path(format: :json),
+           params: { api_token: { name: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "DELETE destroy" do
+    it "deletes the token" do
+      token = FactoryBot.create(:api_token, site: site, user: user)
+
+      expect {
+        delete host + dashboard_api_token_path(token, format: :json)
+      }.to change(Storytime::ApiToken, :count).by(-1)
+    end
+  end
+end

--- a/spec/requests/dashboard_api_tokens_spec.rb
+++ b/spec/requests/dashboard_api_tokens_spec.rb
@@ -45,6 +45,21 @@ describe "Dashboard API tokens", type: :request do
            params: { api_token: { name: "" } }
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it "parses a datepicker date string into an end-of-day expiration" do
+      post host + dashboard_api_tokens_path(format: :json),
+           params: { api_token: { name: "Expiring", expires_at: "July 8, 2026" } }
+
+      token = Storytime::ApiToken.order(:created_at).last
+      expect(token.expires_at).to be_within(1.second).of(Time.zone.parse("July 8, 2026").end_of_day)
+    end
+
+    it "treats a blank expiration as no expiration" do
+      post host + dashboard_api_tokens_path(format: :json),
+           params: { api_token: { name: "Forever", expires_at: "" } }
+
+      expect(Storytime::ApiToken.order(:created_at).last.expires_at).to be_nil
+    end
   end
 
   describe "DELETE destroy" do

--- a/spec/requests/dashboard_artifacts_spec.rb
+++ b/spec/requests/dashboard_artifacts_spec.rb
@@ -27,4 +27,18 @@ describe "Dashboard artifacts", type: :request do
       expect(Storytime::Artifact.find_by(name: "Forever").expires_at).to be_nil
     end
   end
+
+  describe "authorization" do
+    it "forbids a non-admin member from creating artifacts" do
+      writer = FactoryBot.create(:user)
+      Storytime::Membership.create!(user: writer, site: site,
+                                    storytime_role: Storytime::Role.find_by(name: "writer"))
+      sign_in writer
+
+      expect {
+        post host + dashboard_artifacts_path,
+             params: { artifact: { name: "Sneaky", file: html_file } }
+      }.not_to change(Storytime::Artifact, :count)
+    end
+  end
 end

--- a/spec/requests/dashboard_artifacts_spec.rb
+++ b/spec/requests/dashboard_artifacts_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe "Dashboard artifacts", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:site) do
+    s = FactoryBot.create(:site, custom_domain: "www.example.com")
+    s.save_with_seeds(user); s
+  end
+  let(:host) { "http://www.example.com" }
+  let(:html_file) { Rack::Test::UploadedFile.new(File.open("./spec/support/files/sample_artifact.html"), "text/html") }
+
+  before { sign_in user }
+
+  describe "POST create with expiration" do
+    it "parses a datepicker date string into an end-of-day expiration" do
+      post host + dashboard_artifacts_path,
+           params: { artifact: { name: "Expiring", file: html_file, expires_at: "July 8, 2026" } }
+
+      artifact = Storytime::Artifact.find_by(name: "Expiring")
+      expect(artifact.expires_at).to be_within(1.second).of(Time.zone.parse("July 8, 2026").end_of_day)
+    end
+
+    it "treats a blank expiration as no expiration" do
+      post host + dashboard_artifacts_path,
+           params: { artifact: { name: "Forever", file: html_file, expires_at: "" } }
+
+      expect(Storytime::Artifact.find_by(name: "Forever").expires_at).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
   config.include FeatureMacros, type: :feature
   config.include Storytime::Engine.routes.url_helpers
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true

--- a/spec/support/files/sample_artifact.html
+++ b/spec/support/files/sample_artifact.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html><head><title>Sample</title><style>body{color:teal}</style></head>
+<body><h1>Sample artifact body</h1><script>console.log("hi")</script></body></html>


### PR DESCRIPTION
## Summary

Adds an **Artifacts** feature to Storytime for uploading self-contained HTML/CSS/JS/image bundles (a single self-contained `.html` file) and serving them privately from the host site.

Each artifact:
- Is addressed by a **long, unguessable alphanumeric token URL** (`/a/:token`).
- Can have an **optional password gate**; a correct password is remembered **per-artifact for the session**.
- Can have an **optional expiration date**; once past, the link 404s.
- Is served with **`X-Robots-Tag: noindex, nofollow, noarchive`** so it stays out of search engines and sitemaps.

Content is stored in a Postgres `text` column so access control is enforced on every request, rather than relying on a public (fog `fog_public = true`) S3 URL that would bypass the password/expiration gates.

## What's included

- **`Storytime::Artifact` model** + migration (`storytime_artifacts`): unique alphanumeric `token`, `content`, optional `password_digest` (bcrypt via `has_secure_password validations: false`), optional `expires_at`; site-scoped via `ScopedToSite`.
- **Public serving** – `ArtifactsController` at `GET /a/:token` and `POST /a/:token/unlock`, registered ahead of the pages catch-all. Unknown/expired tokens → 404; locked artifacts render a minimal standalone password page.
- **Dashboard** – `Dashboard::ArtifactsController` + views (index/new/edit/form), a new **Artifacts** nav entry, Pundit-authorized (`ArtifactPolicy`). Create / upload / replace / set or clear password / set expiration / delete.

## API access (DB-backed tokens)

- **`Api::V1::ArtifactsController`** at `/api/v1/artifacts`, authenticated with `Authorization: Bearer <token>`. Supports index/show/create/update/delete; accepts a `file` upload or raw `html` plus `password`/`expires_at`; returns `{ token, url, ... }`.
- **`Storytime::ApiToken`** – named, revocable API credentials managed from the dashboard (**Site Settings → API Tokens**), rather than a shared secret in config:
  - Only a **SHA-256 digest** is stored; the raw token (prefixed `sk_`) is shown **once** at creation.
  - Each token **belongs to a user**, so API-created artifacts are attributed to a real person.
  - Optional expiration; successful auth stamps `last_used_at`; revoke by deleting.
  - `Dashboard::ApiTokensController` + `ApiTokenPolicy`; a new tab in the Site Settings modal.

## Tests

**184 examples, 0 failures.** New coverage: artifact model, public-serving request specs (serve / 404 / expired / password flow / noindex header), API request specs (auth + CRUD + creator attribution + last_used_at), ApiToken model (digest-only storage / prefix / authenticate / expiry), dashboard API-token request specs, and non-JS dashboard feature specs for artifacts.

> Note: rebuilding the test DB uses the engine rake tasks (`rake app:db:drop app:db:create app:db:schema:load`, matching CI's `app:db:setup`) so the engine's migration path is registered.

## Upgrading a host app

1. `bundle update storytime`
2. `rake storytime:install:migrations && rails db:migrate`
3. In the dashboard, open **Site Settings → API Tokens** and mint a token for programmatic use.

Example programmatic upload:

```bash
curl -X POST https://your-host-app.example.com/api/v1/artifacts \
  -H "Authorization: Bearer sk_your_token_here" \
  -F name="My Artifact" \
  -F file=@artifact.html \
  -F password=optional -F expires_at="2026-08-01T00:00:00Z"
```

## Deferred (by design)

- Multi-file / zip bundles (current scope is a single self-contained HTML file).
- Cookieless-subdomain / sandboxed-iframe isolation for the same-origin JS (low risk since artifacts are authored by the site owner; the Rails session cookie is `httpOnly`).
