### PR TITLE
Fix OpenRedirectError from anonymous preview requests

### DIFF
--- a/app/controllers/storytime/application_controller.rb
+++ b/app/controllers/storytime/application_controller.rb
@@ -70,6 +70,15 @@ private
 
   def user_not_authorized
     flash[:error] = "You are not authorized to perform this action."
-    redirect_to(request.referrer || "/")
+    # Fall back to root rather than an off-host referrer, which redirect_to
+    # rejects as an unsafe open redirect.
+    redirect_back(fallback_location: "/", allow_other_host: false)
+  end
+
+  # Only signed-in users may preview unpublished/draft content. Anonymous
+  # requests ignore the preview param and fall through to the published post,
+  # so bots hitting ?preview=true don't trip the not-authorized redirect.
+  def preview_request?
+    params[:preview].present? && current_user.present?
   end
 end

--- a/app/controllers/storytime/blogs_controller.rb
+++ b/app/controllers/storytime/blogs_controller.rb
@@ -5,7 +5,7 @@ module Storytime
     before_action :load_page
 
     def show
-      if params[:preview].nil? && params[:id].present? && params[:id] != @page.slug
+      if !preview_request? && params[:id].present? && params[:id] != @page.slug
         return redirect_to @page, :status => :moved_permanently
       end
 
@@ -21,7 +21,7 @@ module Storytime
   private
 
     def load_page
-      @page = if params[:preview]
+      @page = if preview_request?
         page = Post.find_preview(params[:id])
         page.content = page.autosave.content
         page.preview = true

--- a/app/controllers/storytime/pages_controller.rb
+++ b/app/controllers/storytime/pages_controller.rb
@@ -5,7 +5,7 @@ module Storytime
     before_action :load_page
 
     def show
-      if params[:preview].nil? && params[:id].present? && !@page.nil? && params[:id] != @page.slug
+      if !preview_request? && params[:id].present? && !@page.nil? && params[:id] != @page.slug
         return redirect_to @page, :status => :moved_permanently
       end
 
@@ -34,7 +34,7 @@ module Storytime
   private
 
     def load_page
-      @page = if params[:preview]
+      @page = if preview_request?
         page = Post.find_preview(params[:id])
         page.content = page.autosave.content
         page.preview = true

--- a/app/controllers/storytime/posts_controller.rb
+++ b/app/controllers/storytime/posts_controller.rb
@@ -5,19 +5,19 @@ module Storytime
     def show
       params[:id] = params[:id].split("/").last
 
-      @post = if params[:preview]
+      @post = if preview_request?
         Post.find_preview(params[:id])
       else
         Post.published.friendly.find(params[:id])
       end
 
       authorize @post
-      
+
       content_for :title, "#{@current_storytime_site.title} | #{@post.title}"
 
       @comments = @post.comments.order("created_at DESC") if @post.show_comments?
       #allow overriding in the host app
-      if params[:preview].nil? && !view_context.current_page?(storytime.post_path(@post))
+      if !preview_request? && !view_context.current_page?(storytime.post_path(@post))
         redirect_to storytime.post_path(@post), :status => :moved_permanently
       elsif lookup_context.template_exists?("storytime/#{@current_storytime_site.custom_view_path}/#{@post.type_name.pluralize}/#{@post.slug}")
         render "storytime/#{@current_storytime_site.custom_view_path}/#{@post.type_name.pluralize}/#{@post.slug}"


### PR DESCRIPTION
## Problem

Airbrake was reporting `ActionController::Redirecting::OpenRedirectError` on `posts#show`. Root cause traced through the actual crash path:

1. An anonymous visitor (an Android bot in the reported occurrence) hits a post URL with `?preview=true`.
2. `Post.find_preview` sets `@post.preview = true`, so `PostPolicy#show?` routes through `manage?`, which is `false` for a nil user → `Pundit::NotAuthorizedError`.
3. The `rescue_from` handler `user_not_authorized` ran `redirect_to(request.referrer || "/")`. The referrer host (`cultivatelabs.com`) differed from the request host (`www.cultivatelabs.com`), so Rails rejected it as an unsafe open redirect and raised.

## Fix

- Add `preview_request?` on `ApplicationController` (preview param **and** signed-in user). Anonymous `?preview=true` requests now ignore the param, serve the published post, and get the normal canonical 301 – they never reach the not-authorized branch.
- Harden `user_not_authorized` to `redirect_back(fallback_location: "/", allow_other_host: false)` so an off-host referrer can never crash the handler again (defends every unauthorized action, not just this one).
- Apply the signed-in preview guard consistently across `posts`, `blogs`, and `pages` controllers.

## Testing

Existing dashboard preview spec (logged-in flow) is unaffected. Anonymous preview behavior changes intentionally: published post is served with canonical redirect instead of raising.